### PR TITLE
refactor: rename demo classes for consistency and clarity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,18 +19,18 @@
 
     <!-- Spine: an in-page table of contents, not a switcher. The active link
          is driven purely by scroll position (view-timeline) — no JS. -->
-    <nav class="spy-nav" aria-label="On this page">
-      <ul class="spy-list" role="list">
+    <nav class="scrollspy-nav" aria-label="On this page">
+      <ul class="scrollspy-list" role="list">
         <li>
-          <a class="spy-link" data-spy="standard" href="#standard">
+          <a class="scrollspy-link" data-spy="standard" href="#standard">
             The standard
           </a>
         </li>
         <li>
-          <a class="spy-link" data-spy="craft" href="#craft">The craft</a>
+          <a class="scrollspy-link" data-spy="craft" href="#craft">The craft</a>
         </li>
         <li>
-          <a class="spy-link" data-spy="showcase" href="#showcase">
+          <a class="scrollspy-link" data-spy="showcase" href="#showcase">
             CSS showcase
           </a>
         </li>
@@ -41,7 +41,7 @@
       <!-- ===================================================================
            Pillar 1 — The requirement: accessibility as a living standard
       ==================================================================== -->
-      <div id="standard" class="pillar spy-region">
+      <div id="standard" class="pillar scrollspy-region">
         <p class="pillar-eyebrow">01 · The requirement</p>
 
         <section class="demo" aria-labelledby="demo-criteria">
@@ -86,7 +86,7 @@
       <!-- ===================================================================
            Pillar 2 — The platform's answer (a) shipping today: the craft
       ==================================================================== -->
-      <div id="craft" class="pillar spy-region">
+      <div id="craft" class="pillar scrollspy-region">
         <p class="pillar-eyebrow">02 · The platform's answer · shipping today</p>
         <p class="pillar-lead">
           The standard sets the bar; modern CSS and HTML clear most of it with no
@@ -193,7 +193,7 @@
       <!-- ===================================================================
            Pillar 2 — The platform's answer (b) arriving next: the showcase
       ==================================================================== -->
-      <div id="showcase" class="pillar spy-region">
+      <div id="showcase" class="pillar scrollspy-region">
         <p class="pillar-eyebrow">03 · The platform's answer · arriving next</p>
 
         <section class="demo" aria-labelledby="demo-css">
@@ -406,7 +406,7 @@ const groups = computed(() => [
   /* --- Spine navigation ----------------------------------------------------
      A sticky in-page table of contents. It floats over scrolling content with
      the same glassy treatment as the rest of the shell. */
-  .spy-nav {
+  .scrollspy-nav {
     position: sticky;
     inset-block-start: var(--space-2);
     z-index: 5;
@@ -430,13 +430,13 @@ const groups = computed(() => [
     }
   }
 
-  .spy-list {
+  .scrollspy-list {
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: 1fr;
   }
 
-  .spy-link {
+  .scrollspy-link {
     display: grid;
     place-items: center;
     min-block-size: 44px;
@@ -474,20 +474,20 @@ const groups = computed(() => [
     #craft { view-timeline-name: --vt-craft; }
     #showcase { view-timeline-name: --vt-showcase; }
 
-    .spy-link {
-      animation: spy-active linear both;
+    .scrollspy-link {
+      animation: scrollspy-active linear both;
       animation-range: cover 0% cover 100%;
     }
 
-    .spy-link[data-spy='standard'] { animation-timeline: --vt-standard; }
-    .spy-link[data-spy='craft'] { animation-timeline: --vt-craft; }
-    .spy-link[data-spy='showcase'] { animation-timeline: --vt-showcase; }
+    .scrollspy-link[data-spy='standard'] { animation-timeline: --vt-standard; }
+    .scrollspy-link[data-spy='craft'] { animation-timeline: --vt-craft; }
+    .scrollspy-link[data-spy='showcase'] { animation-timeline: --vt-showcase; }
 
     /* A plateau, not a single peak: the link reaches full strength early and
        holds it across the bulk of the region (12%–88% of its cover range),
        fading only at the hand-off edges. That keeps the active link clearly
        lit even at the top of a very tall region, while neighbours stay dark. */
-    @keyframes spy-active {
+    @keyframes scrollspy-active {
       0%,
       100% {
         background-color: transparent;
@@ -506,12 +506,12 @@ const groups = computed(() => [
     /* In forced-colors the crossfade colors collapse to system values; give the
        active link a clear, non-color boundary instead. */
     @include forced-colors {
-      .spy-link {
-        animation: spy-active-hc linear both;
+      .scrollspy-link {
+        animation: scrollspy-active-hc linear both;
         animation-range: cover 0% cover 100%;
       }
 
-      @keyframes spy-active-hc {
+      @keyframes scrollspy-active-hc {
         0%,
         100% {
           border: 1px solid transparent;

--- a/src/craft/demos/LightDarkDemo.vue
+++ b/src/craft/demos/LightDarkDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="ld-demo">
-    <p class="ld-caption">
+  <div class="light-dark-demo">
+    <p class="light-dark-caption">
       Two ways to give one swatch a light and a dark value. They look identical
       at rest — until you <strong>flip the theme toggle in the header</strong>.
       The <code>light-dark()</code> swatch follows your choice; the
@@ -11,14 +11,14 @@
       — the thing a theme toggle actually changes.
     </p>
 
-    <div class="ld-grid">
-      <article class="ld-card">
-        <h3 class="ld-card-title">
+    <div class="light-dark-grid">
+      <article class="light-dark-card">
+        <h3 class="light-dark-card-title">
           <code>light-dark()</code> — follows the toggle
         </h3>
-        <div class="ld-swatch ld-swatch-modern" aria-hidden="true"></div>
-        <pre class="ld-code"><code>color: light-dark(#1a1a2e, #e6e6fa);</code></pre>
-        <p class="ld-note">
+        <div class="light-dark-swatch light-dark-swatch-modern" aria-hidden="true"></div>
+        <pre class="light-dark-code"><code>color: light-dark(#1a1a2e, #e6e6fa);</code></pre>
+        <p class="light-dark-note">
           One line, both values together so they can’t drift — and because it
           resolves against <code>color-scheme</code>, it honours the user’s
           in-app theme choice <em>and</em> their OS preference. The foundation
@@ -26,17 +26,17 @@
         </p>
       </article>
 
-      <article class="ld-card">
-        <h3 class="ld-card-title">
+      <article class="light-dark-card">
+        <h3 class="light-dark-card-title">
           <code>@media</code> — only hears the OS
         </h3>
-        <div class="ld-swatch ld-swatch-legacy" aria-hidden="true"></div>
-        <pre class="ld-code"><code>color: #1a1a2e;
+        <div class="light-dark-swatch light-dark-swatch-legacy" aria-hidden="true"></div>
+        <pre class="light-dark-code"><code>color: #1a1a2e;
 
 @media (prefers-color-scheme: dark) {
   color: #e6e6fa;
 }</code></pre>
-        <p class="ld-note">
+        <p class="light-dark-note">
           The values are split across two declarations (easy to update one and
           forget the other) — and the query tracks the <em>OS</em> setting, so
           this swatch ignores the header toggle entirely. With a manual theme
@@ -53,23 +53,23 @@
 
 <style scoped lang="scss">
 @layer components {
-  .ld-demo {
+  .light-dark-demo {
     display: grid;
     gap: var(--space-4);
   }
 
-  .ld-caption {
+  .light-dark-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .ld-grid {
+  .light-dark-grid {
     display: grid;
     gap: var(--space-4);
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
   }
 
-  .ld-card {
+  .light-dark-card {
     display: grid;
     gap: var(--space-3);
     align-content: start;
@@ -83,25 +83,25 @@
     }
   }
 
-  .ld-card-title {
+  .light-dark-card-title {
     font-size: var(--text-base);
     font-weight: 600;
   }
 
-  .ld-swatch {
+  .light-dark-swatch {
     block-size: var(--space-12);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
   }
 
   /* The modern swatch: one declaration, both modes. */
-  .ld-swatch-modern {
+  .light-dark-swatch-modern {
     background-color: light-dark(#1a1a2e, #e6e6fa);
   }
 
   /* The legacy swatch: base value + a media-query override. Identical result,
      authored as two separate declarations that have to be kept in sync. */
-  .ld-swatch-legacy {
+  .light-dark-swatch-legacy {
     background-color: #1a1a2e;
 
     @include dark-mode {
@@ -109,7 +109,7 @@
     }
   }
 
-  .ld-code {
+  .light-dark-code {
     overflow-x: auto;
     padding: var(--space-3);
     border-radius: var(--radius-sm);
@@ -118,7 +118,7 @@
     white-space: pre;
   }
 
-  .ld-note {
+  .light-dark-note {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/criteria/ConformanceShift/ConformanceShift.scss
+++ b/src/criteria/ConformanceShift/ConformanceShift.scss
@@ -1,11 +1,11 @@
 /* Library mixins are injected via Vite's additionalData, so no @use here. */
 @layer components {
-  .cshift {
+  .conformance-shift {
     display: grid;
     gap: var(--space-4);
   }
 
-  .cshift-control {
+  .conformance-shift-control {
     display: grid;
     gap: var(--space-2);
     max-inline-size: 32rem;
@@ -16,19 +16,19 @@
     }
   }
 
-  .cshift-count {
+  .conformance-shift-count {
     font-family: var(--font-mono);
     color: var(--color-text-subtle);
   }
 
-  .cshift-panels {
+  .conformance-shift-panels {
     /* Two panels side by side when there's room, stacked when tight. */
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
     gap: var(--space-4);
   }
 
-  .cshift-panel {
+  .conformance-shift-panel {
     display: grid;
     gap: var(--space-2);
     align-content: start;
@@ -43,7 +43,7 @@
     }
   }
 
-  .cshift-panel-title {
+  .conformance-shift-panel-title {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
@@ -51,7 +51,7 @@
 
   /* Binary verdict: the tone color is backed by the word itself (pass/fail),
      never color alone. */
-  .cshift-verdict {
+  .conformance-shift-verdict {
     font-size: var(--text-2xl);
     font-weight: 700;
 
@@ -64,7 +64,7 @@
     }
   }
 
-  .cshift-score {
+  .conformance-shift-score {
     display: flex;
     align-items: baseline;
     gap: var(--space-2);
@@ -72,19 +72,19 @@
     font-weight: 700;
   }
 
-  .cshift-pct {
+  .conformance-shift-pct {
     font-size: var(--text-lg);
     color: var(--color-text-subtle);
   }
 
-  .cshift-rating {
+  .conformance-shift-rating {
     margin-inline-start: auto;
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
   }
 
-  .cshift-meter {
+  .conformance-shift-meter {
     block-size: var(--space-2);
     border-radius: var(--radius-full);
     background-color: var(--color-bg-subtle);
@@ -95,7 +95,7 @@
     }
   }
 
-  .cshift-meter-fill {
+  .conformance-shift-meter-fill {
     display: block;
     block-size: 100%;
     border-radius: inherit;
@@ -108,12 +108,12 @@
     }
   }
 
-  .cshift-caption {
+  .conformance-shift-caption {
     max-inline-size: 65ch;
     color: var(--color-text-subtle);
   }
 
-  .cshift-disclaimer {
+  .conformance-shift-disclaimer {
     font-style: italic;
   }
 }

--- a/src/criteria/ConformanceShift/ConformanceShift.vue
+++ b/src/criteria/ConformanceShift/ConformanceShift.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="cshift">
-    <div class="cshift-control">
+  <div class="conformance-shift">
+    <div class="conformance-shift-control">
       <label :for="sliderId">
-        Failing checks <span class="cshift-count">{{ failing }} / {{ total }}</span>
+        Failing checks <span class="conformance-shift-count">{{ failing }} / {{ total }}</span>
       </label>
       <input
         :id="sliderId"
@@ -14,50 +14,50 @@
       />
     </div>
 
-    <div class="cshift-panels">
-      <article class="cshift-panel" aria-labelledby="cshift-binary">
-        <h4 id="cshift-binary" class="cshift-panel-title">
+    <div class="conformance-shift-panels">
+      <article class="conformance-shift-panel" aria-labelledby="conformance-shift-binary">
+        <h4 id="conformance-shift-binary" class="conformance-shift-panel-title">
           WCAG 2.x — pass / fail
         </h4>
-        <p class="cshift-verdict" :class="`is-${binary.tone}`">
+        <p class="conformance-shift-verdict" :class="`is-${binary.tone}`">
           {{ binary.label }}
         </p>
-        <p class="cshift-note">
+        <p class="conformance-shift-note">
           A single failure fails the whole level. All-or-nothing, however
           close you got.
         </p>
       </article>
 
-      <article class="cshift-panel" aria-labelledby="cshift-graded">
-        <h4 id="cshift-graded" class="cshift-panel-title">
+      <article class="conformance-shift-panel" aria-labelledby="conformance-shift-graded">
+        <h4 id="conformance-shift-graded" class="conformance-shift-panel-title">
           WCAG 3.0 (draft) — scored
         </h4>
-        <p class="cshift-score">
-          {{ score }}<span class="cshift-pct">%</span>
-          <span class="cshift-rating">{{ rating }}</span>
+        <p class="conformance-shift-score">
+          {{ score }}<span class="conformance-shift-pct">%</span>
+          <span class="conformance-shift-rating">{{ rating }}</span>
         </p>
         <div
-          class="cshift-meter"
+          class="conformance-shift-meter"
           role="meter"
           :aria-valuenow="score"
           aria-valuemin="0"
           aria-valuemax="100"
           :aria-label="`Outcome score ${score} percent`"
         >
-          <span class="cshift-meter-fill" :style="{ inlineSize: score + '%' }"></span>
+          <span class="conformance-shift-meter-fill" :style="{ inlineSize: score + '%' }"></span>
         </div>
-        <p class="cshift-note">
+        <p class="conformance-shift-note">
           Partial credit; the score degrades gradually toward a rating
           instead of flipping to a hard fail.
         </p>
       </article>
     </div>
 
-    <p class="cshift-caption">
+    <p class="conformance-shift-caption">
       The biggest change coming in <strong>WCAG 3.0</strong> isn't more
       criteria — it's the <em>model</em>: away from binary A / AA / AAA toward
       graded, outcome-based scoring that rewards how well you actually serve
-      people. <span class="cshift-disclaimer">(Illustrative — 3.0's exact
+      people. <span class="conformance-shift-disclaimer">(Illustrative — 3.0's exact
       scoring is still a working draft.)</span>
     </p>
   </div>

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -29,14 +29,14 @@
     }
   }
 
-  .era {
+  .timeline-era {
     display: grid;
     grid-template-columns: var(--space-6) minmax(0, 1fr);
     column-gap: var(--space-4);
     align-items: start;
   }
 
-  .era-marker {
+  .timeline-era-marker {
     position: relative;
     z-index: 1;
     justify-self: center;
@@ -59,22 +59,22 @@
   }
 
   /* Foundation (2.0) and future (3.0) eras have no demos — hollow marker. */
-  .era.is-open .era-marker {
+  .timeline-era.is-open .timeline-era-marker {
     background: var(--color-bg);
     border-color: var(--color-primary);
   }
 
-  .era-body {
+  .timeline-era-body {
     display: grid;
     gap: var(--space-4);
   }
 
-  .era-header {
+  .timeline-era-header {
     display: grid;
     gap: var(--space-1);
   }
 
-  .era-title {
+  .timeline-era-title {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
@@ -82,23 +82,23 @@
     font-size: var(--text-xl);
   }
 
-  .era-year {
+  .timeline-era-year {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .era-summary {
+  .timeline-era-summary {
     max-inline-size: 60ch;
     color: var(--color-text-subtle);
   }
 
-  .era-criteria {
+  .timeline-era-criteria {
     display: grid;
     gap: var(--space-6);
   }
 
-  .era-note {
+  .timeline-era-note {
     max-inline-size: 60ch;
     padding: var(--space-3) var(--space-4);
     border: 1px dashed var(--color-border);
@@ -136,7 +136,7 @@
         animation-range: cover 12% cover 96%;
       }
 
-      .era-marker {
+      .timeline-era-marker {
         animation: marker-pop linear both;
         animation-timeline: view();
         animation-range: entry 0% cover 12%;

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
@@ -5,19 +5,19 @@
     <li
       v-for="era in eras"
       :key="era.id"
-      class="era"
+      class="timeline-era"
       :class="{ 'is-open': !era.items.length }"
     >
-      <span class="era-marker" aria-hidden="true"></span>
-      <div class="era-body">
-        <header class="era-header">
-          <h3 class="era-title">
-            {{ era.label }} <span class="era-year">{{ era.year }}</span>
+      <span class="timeline-era-marker" aria-hidden="true"></span>
+      <div class="timeline-era-body">
+        <header class="timeline-era-header">
+          <h3 class="timeline-era-title">
+            {{ era.label }} <span class="timeline-era-year">{{ era.year }}</span>
           </h3>
-          <p class="era-summary">{{ era.summary }}</p>
+          <p class="timeline-era-summary">{{ era.summary }}</p>
         </header>
 
-        <div v-if="era.items.length" class="era-criteria">
+        <div v-if="era.items.length" class="timeline-era-criteria">
           <CriterionFrame
             v-for="c in era.items"
             :key="c.id"
@@ -38,7 +38,7 @@
             <component :is="c.component" :broken="broken" />
           </CriterionFrame>
         </div>
-        <p v-else class="era-note">{{ era.note }}</p>
+        <p v-else class="timeline-era-note">{{ era.note }}</p>
       </div>
     </li>
   </ol>

--- a/src/criteria/LegalMap/LegalMap.scss
+++ b/src/criteria/LegalMap/LegalMap.scss
@@ -1,13 +1,13 @@
 /* Library mixins are injected via Vite's additionalData, so no @use here. */
 @layer components {
-  .lmap {
+  .legal-map {
     display: grid;
     gap: var(--space-6);
   }
 
   /* The core sits above the laws; the accent gradient marks it as the thing
      everything else references. */
-  .lmap-core {
+  .legal-map-core {
     display: grid;
     gap: var(--space-1);
     justify-items: center;
@@ -26,18 +26,18 @@
     }
   }
 
-  .lmap-core-label {
+  .legal-map-core-label {
     font-size: var(--text-2xl);
     font-weight: 700;
     letter-spacing: var(--tracking-tight);
   }
 
-  .lmap-core-sub {
+  .legal-map-core-sub {
     font-size: var(--text-sm);
     opacity: 0.9;
   }
 
-  .lmap-laws {
+  .legal-map-laws {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
     gap: var(--space-4);
@@ -46,7 +46,7 @@
     list-style: none;
   }
 
-  .lmap-law {
+  .legal-map-law {
     display: grid;
     gap: var(--space-1);
     align-content: start;
@@ -61,33 +61,33 @@
     }
   }
 
-  .lmap-region {
+  .legal-map-region {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
   }
 
-  .lmap-name {
+  .legal-map-name {
     font-weight: 600;
   }
 
-  .lmap-ref {
+  .legal-map-ref {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--color-primary);
   }
 
-  .lmap-status {
+  .legal-map-status {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .lmap-caption {
+  .legal-map-caption {
     max-inline-size: 65ch;
     color: var(--color-text-subtle);
   }
 
-  .lmap-disclaimer {
+  .legal-map-disclaimer {
     font-style: italic;
   }
 }

--- a/src/criteria/LegalMap/LegalMap.vue
+++ b/src/criteria/LegalMap/LegalMap.vue
@@ -1,24 +1,24 @@
 <template>
-  <div class="lmap">
-    <div class="lmap-core">
-      <p class="lmap-core-label">WCAG</p>
-      <p class="lmap-core-sub">the technical core every law below points to</p>
+  <div class="legal-map">
+    <div class="legal-map-core">
+      <p class="legal-map-core-label">WCAG</p>
+      <p class="legal-map-core-sub">the technical core every law below points to</p>
     </div>
 
-    <ul class="lmap-laws">
-      <li v-for="law in laws" :key="law.region" class="lmap-law">
-        <p class="lmap-region">{{ law.region }}</p>
-        <p class="lmap-name">{{ law.name }}</p>
-        <p class="lmap-ref">→ {{ law.references }}</p>
-        <p class="lmap-status">{{ law.status }}</p>
+    <ul class="legal-map-laws">
+      <li v-for="law in laws" :key="law.region" class="legal-map-law">
+        <p class="legal-map-region">{{ law.region }}</p>
+        <p class="legal-map-name">{{ law.name }}</p>
+        <p class="legal-map-ref">→ {{ law.references }}</p>
+        <p class="legal-map-status">{{ law.status }}</p>
       </li>
     </ul>
 
-    <p class="lmap-caption">
+    <p class="legal-map-caption">
       Accessibility law is global and converging: different jurisdictions wrap
       their own legal force around the <em>same</em> technical standard. Get
       WCAG right and you're most of the way to compliance everywhere.
-      <span class="lmap-disclaimer">(A simplified snapshot — exact versions,
+      <span class="legal-map-disclaimer">(A simplified snapshot — exact versions,
       levels, and dates vary and keep evolving; check the current text for
       your jurisdiction.)</span>
     </p>

--- a/src/criteria/demos/AnimationDemo.vue
+++ b/src/criteria/demos/AnimationDemo.vue
@@ -1,26 +1,26 @@
 <template>
-  <div class="am-demo" :class="{ 'is-broken': broken, 'is-rm': simulateRm }">
-    <p class="am-caption">
+  <div class="animation-demo" :class="{ 'is-broken': broken, 'is-rm': simulateRm }">
+    <p class="animation-caption">
       Reload the panel to replay its entry motion. Then turn on the
       simulated preference and reload again: compliant goes still, broken
       keeps sliding. (Your real OS reduced-motion setting works too.)
     </p>
 
-    <label class="am-sim">
+    <label class="animation-sim">
       <input v-model="simulateRm" type="checkbox" />
       <span>Simulate: I prefer reduced motion</span>
     </label>
 
-    <div class="am-stage">
+    <div class="animation-stage">
       <!-- :key remounts the panel on each click, replaying the CSS entry
            animation — a clean interaction-triggered motion. -->
-      <article :key="playId" class="am-panel">
-        <p class="am-panel-title">Message sent</p>
-        <p class="am-panel-text">Your changes are saved.</p>
+      <article :key="playId" class="animation-panel">
+        <p class="animation-panel-title">Message sent</p>
+        <p class="animation-panel-text">Your changes are saved.</p>
       </article>
     </div>
 
-    <button class="am-replay" type="button" @click="playId++">
+    <button class="animation-replay" type="button" @click="playId++">
       Reload panel
     </button>
   </div>
@@ -39,7 +39,7 @@ const playId = ref(0)
 
 <style scoped lang="scss">
 @layer components {
-  .am-demo {
+  .animation-demo {
     /* One switch governs all motion: 0 = motion allowed, 1 = suppressed.
        The compliant cascade flips it to 1 when the preference is set
        (simulated OR real); the broken state forces it back to 0. */
@@ -54,22 +54,22 @@ const playId = ref(0)
   }
 
   /* Compliant respects a simulated preference… */
-  .am-demo.is-rm {
+  .animation-demo.is-rm {
     --rm: 1;
   }
 
   /* …but broken ignores the preference entirely — declared last so it wins
      over both the simulated and the real (media-query) overrides above. */
-  .am-demo.is-broken {
+  .animation-demo.is-broken {
     --rm: 0;
   }
 
-  .am-caption {
+  .animation-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .am-sim {
+  .animation-sim {
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
@@ -77,13 +77,13 @@ const playId = ref(0)
     cursor: pointer;
   }
 
-  .am-stage {
+  .animation-stage {
     /* Clip the slide so it can't introduce horizontal scrolling. */
     overflow: hidden;
     padding: var(--space-1);
   }
 
-  .am-panel {
+  .animation-panel {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-3);
@@ -93,23 +93,23 @@ const playId = ref(0)
 
     /* Duration collapses to 0 when --rm is 1, so the panel simply appears
        with no motion. No per-state duplication — the switch does it. */
-    animation: am-slide calc(450ms * (1 - var(--rm))) var(--easing-enter) both;
+    animation: animation-slide calc(450ms * (1 - var(--rm))) var(--easing-enter) both;
 
     @include high-contrast {
       border-color: currentcolor;
     }
   }
 
-  .am-panel-title {
+  .animation-panel-title {
     font-weight: 600;
   }
 
-  .am-panel-text {
+  .animation-panel-text {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .am-replay {
+  .animation-replay {
     justify-self: start;
     min-block-size: 44px;
     padding: var(--space-2) var(--space-4);
@@ -135,7 +135,7 @@ const playId = ref(0)
     }
   }
 
-  @keyframes am-slide {
+  @keyframes animation-slide {
     from {
       opacity: 0;
       transform: translateX(-1.5rem);

--- a/src/criteria/demos/FocusAppearanceDemo.vue
+++ b/src/criteria/demos/FocusAppearanceDemo.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="fa-demo" :class="{ 'is-broken': broken }">
-    <p class="fa-caption">
+  <div class="focus-appearance-demo" :class="{ 'is-broken': broken }">
+    <p class="focus-appearance-caption">
       Tab onto these buttons. Compliant, the focus indicator is thick and
       high-contrast — unmistakable. Broken, it shrinks to a faint 1px line
       you have to hunt for.
     </p>
 
-    <div class="fa-buttons" role="group" aria-label="Example actions">
-      <button v-for="action in actions" :key="action" class="fa-btn" type="button">
+    <div class="focus-appearance-buttons" role="group" aria-label="Example actions">
+      <button v-for="action in actions" :key="action" class="focus-appearance-btn" type="button">
         {{ action }}
       </button>
     </div>
@@ -24,23 +24,23 @@ const actions = ['Save', 'Duplicate', 'Archive', 'Delete']
 
 <style scoped lang="scss">
 @layer components {
-  .fa-demo {
+  .focus-appearance-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .fa-caption {
+  .focus-appearance-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .fa-buttons {
+  .focus-appearance-buttons {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-3);
   }
 
-  .fa-btn {
+  .focus-appearance-btn {
     min-block-size: 44px;
     padding: var(--space-2) var(--space-4);
     border: 1px solid var(--color-border);
@@ -69,7 +69,7 @@ const actions = ['Save', 'Duplicate', 'Archive', 'Delete']
      overriding with !important. That this takes !important IS the lesson:
      the foundation protects the ring; you have to actively fight it to fail. */
   .is-broken {
-    .fa-btn:focus-visible {
+    .focus-appearance-btn:focus-visible {
       /* stylelint-disable declaration-no-important -- deliberately simulating the anti-pattern */
       outline: 1px solid var(--color-border) !important;
       outline-offset: 0 !important;

--- a/src/criteria/demos/FocusObscuredDemo.vue
+++ b/src/criteria/demos/FocusObscuredDemo.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="fo-demo" :class="{ 'is-broken': broken }">
-    <p class="fo-caption">
+  <div class="focus-obscured-demo" :class="{ 'is-broken': broken }">
+    <p class="focus-obscured-caption">
       Tab through the links below. A sticky bar sits at the top of this
       scrolling panel — when the rule is broken it overlaps whatever you
       tab to near the top, so keyboard users lose sight of their own focus.
     </p>
 
-    <div class="fo-viewport">
-      <div class="fo-bar">Sticky toolbar</div>
-      <nav class="fo-list" aria-label="Settings">
-        <a v-for="item in items" :key="item" class="fo-link" href="#fo-noop">
+    <div class="focus-obscured-viewport">
+      <div class="focus-obscured-bar">Sticky toolbar</div>
+      <nav class="focus-obscured-list" aria-label="Settings">
+        <a v-for="item in items" :key="item" class="focus-obscured-link" href="#focus-obscured-noop">
           {{ item }}
         </a>
       </nav>
@@ -36,17 +36,17 @@ const items = [
 
 <style scoped lang="scss">
 @layer components {
-  .fo-demo {
+  .focus-obscured-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .fo-caption {
+  .focus-obscured-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .fo-viewport {
+  .focus-obscured-viewport {
     position: relative;
     max-block-size: 12rem;
     overflow-y: auto;
@@ -58,7 +58,7 @@ const items = [
     }
   }
 
-  .fo-bar {
+  .focus-obscured-bar {
     position: sticky;
     inset-block-start: 0;
     z-index: 1;
@@ -68,11 +68,11 @@ const items = [
     font-weight: 600;
   }
 
-  .fo-list {
+  .focus-obscured-list {
     display: grid;
   }
 
-  .fo-link {
+  .focus-obscured-link {
     /* The fix: scroll-margin keeps a focused link clear of the sticky bar
        when it's scrolled into view, so the focus ring is never obscured. */
     scroll-margin-block-start: var(--space-12);
@@ -97,7 +97,7 @@ const items = [
      behind it. Nothing else changes; focus still moves correctly, you just
      can't see where it is. */
   .is-broken {
-    .fo-link {
+    .focus-obscured-link {
       scroll-margin-block-start: 0;
     }
   }

--- a/src/criteria/demos/NonTextContrastDemo.vue
+++ b/src/criteria/demos/NonTextContrastDemo.vue
@@ -1,21 +1,21 @@
 <template>
-  <div class="ntc-demo" :class="{ 'is-broken': broken }">
-    <p class="ntc-caption">
+  <div class="non-text-contrast-demo" :class="{ 'is-broken': broken }">
+    <p class="non-text-contrast-caption">
       These controls are outlined only by their borders. Below 3:1 those
       boundaries melt into the background — the inputs are still there, but
       can you see where they are?
     </p>
 
-    <div class="ntc-fields">
+    <div class="non-text-contrast-fields">
       <input
-        class="ntc-input"
+        class="non-text-contrast-input"
         type="text"
         placeholder="Search"
         aria-label="Search"
       />
-      <button class="ntc-btn" type="button">Filter</button>
-      <ul class="ntc-chips" aria-label="Quick filters">
-        <li v-for="chip in chips" :key="chip" class="ntc-chip">{{ chip }}</li>
+      <button class="non-text-contrast-btn" type="button">Filter</button>
+      <ul class="non-text-contrast-chips" aria-label="Quick filters">
+        <li v-for="chip in chips" :key="chip" class="non-text-contrast-chip">{{ chip }}</li>
       </ul>
     </div>
   </div>
@@ -31,7 +31,7 @@ const chips = ['Unread', 'Starred']
 
 <style scoped lang="scss">
 @layer components {
-  .ntc-demo {
+  .non-text-contrast-demo {
     /* The single border color the controls share. Compliant value sits at
        ~3.5:1 against the surface in both themes; the broken override drops
        it to ~1.2:1. Hardcoded here because the contrast ratio IS the
@@ -42,19 +42,19 @@ const chips = ['Unread', 'Starred']
     gap: var(--space-3);
   }
 
-  .ntc-caption {
+  .non-text-contrast-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .ntc-fields {
+  .non-text-contrast-fields {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-3);
   }
 
-  .ntc-input {
+  .non-text-contrast-input {
     min-block-size: 44px;
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--demo-border);
@@ -69,7 +69,7 @@ const chips = ['Unread', 'Starred']
     }
   }
 
-  .ntc-btn {
+  .non-text-contrast-btn {
     min-block-size: 44px;
     padding: var(--space-2) var(--space-4);
     border: 1px solid var(--demo-border);
@@ -84,7 +84,7 @@ const chips = ['Unread', 'Starred']
     }
   }
 
-  .ntc-chips {
+  .non-text-contrast-chips {
     display: flex;
     gap: var(--space-2);
     margin: 0;
@@ -92,7 +92,7 @@ const chips = ['Unread', 'Starred']
     list-style: none;
   }
 
-  .ntc-chip {
+  .non-text-contrast-chip {
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--demo-border);
     border-radius: var(--radius-full);

--- a/src/criteria/demos/OrientationDemo.vue
+++ b/src/criteria/demos/OrientationDemo.vue
@@ -1,31 +1,31 @@
 <template>
-  <div class="or-demo" :class="{ 'is-broken': broken, 'is-landscape': landscape }">
-    <p class="or-caption">
+  <div class="orientation-demo" :class="{ 'is-broken': broken, 'is-landscape': landscape }">
+    <p class="orientation-caption">
       A little app inside a device frame. Rotate it. Compliant works either
       way; broken demands landscape and walls off portrait — locking out
       anyone whose device is fixed in one orientation (a tablet mounted to
       a wheelchair, say).
     </p>
 
-    <div class="or-stage">
-      <div class="or-device">
+    <div class="orientation-stage">
+      <div class="orientation-device">
         <!-- Both states are always in the DOM; CSS shows the right one for
              the current orientation + rule state, so only orientation
              handling changes between compliant and broken. -->
-        <div class="or-screen">
-          <p class="or-screen-title">Today</p>
-          <p class="or-screen-row">7,204 steps</p>
-          <p class="or-screen-row">3 reminders</p>
-          <p class="or-screen-row">2 messages</p>
+        <div class="orientation-screen">
+          <p class="orientation-screen-title">Today</p>
+          <p class="orientation-screen-row">7,204 steps</p>
+          <p class="orientation-screen-row">3 reminders</p>
+          <p class="orientation-screen-row">2 messages</p>
         </div>
-        <div class="or-rotate-notice" role="alert">
-          <span class="or-rotate-icon" aria-hidden="true">⟳</span>
+        <div class="orientation-rotate-notice" role="alert">
+          <span class="orientation-rotate-icon" aria-hidden="true">⟳</span>
           <p>Please rotate your device to landscape to continue.</p>
         </div>
       </div>
     </div>
 
-    <button class="or-rotate-btn" type="button" @click="landscape = !landscape">
+    <button class="orientation-rotate-btn" type="button" @click="landscape = !landscape">
       Rotate device ({{ landscape ? 'landscape' : 'portrait' }})
     </button>
   </div>
@@ -43,23 +43,23 @@ const landscape = ref(false)
 
 <style scoped lang="scss">
 @layer components {
-  .or-demo {
+  .orientation-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .or-caption {
+  .orientation-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .or-stage {
+  .orientation-stage {
     display: flex;
     justify-content: center;
     padding: var(--space-2);
   }
 
-  .or-device {
+  .orientation-device {
     position: relative;
     display: grid;
     inline-size: 11rem;
@@ -76,12 +76,12 @@ const landscape = ref(false)
 
   /* Rotating swaps the device's dimensions. The .is-landscape class lives
      on the demo root, so the device is targeted as a descendant. */
-  .is-landscape .or-device {
+  .is-landscape .orientation-device {
     inline-size: 17rem;
     block-size: 11rem;
   }
 
-  .or-screen {
+  .orientation-screen {
     display: grid;
     gap: var(--space-2);
     align-content: start;
@@ -90,17 +90,17 @@ const landscape = ref(false)
     background-color: var(--color-surface);
   }
 
-  .or-screen-title {
+  .orientation-screen-title {
     font-size: var(--text-lg);
     font-weight: 600;
   }
 
-  .or-screen-row {
+  .orientation-screen-row {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .or-rotate-notice {
+  .orientation-rotate-notice {
     /* Hidden by default — the app works in every orientation. */
     display: none;
     place-content: center;
@@ -111,23 +111,23 @@ const landscape = ref(false)
     font-size: var(--text-sm);
   }
 
-  .or-rotate-icon {
+  .orientation-rotate-icon {
     font-size: var(--text-3xl);
   }
 
   /* The regression: the app only supports landscape, so in portrait it
      blocks the content behind a "rotate your device" wall. */
   .is-broken:not(.is-landscape) {
-    .or-screen {
+    .orientation-screen {
       display: none;
     }
 
-    .or-rotate-notice {
+    .orientation-rotate-notice {
       display: grid;
     }
   }
 
-  .or-rotate-btn {
+  .orientation-rotate-btn {
     justify-self: start;
     min-block-size: 44px;
     padding: var(--space-2) var(--space-4);

--- a/src/criteria/demos/ReflowDemo.vue
+++ b/src/criteria/demos/ReflowDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="rf-demo" :class="{ 'is-broken': broken }">
-    <p class="rf-caption">
+  <div class="reflow-demo" :class="{ 'is-broken': broken }">
+    <p class="reflow-caption">
       This panel is ~340px wide — like a phone, or a 1280px desktop zoomed
       to 400%, which is the width 1.4.10 targets. Scroll it.
     </p>
@@ -10,21 +10,21 @@
          here IS the failure you can see and feel. It's keyboard-focusable so
          the scrollable area is reachable without a pointer. -->
     <div
-      class="rf-viewport"
+      class="reflow-viewport"
       tabindex="0"
       role="group"
       aria-label="Account overview panel, scrollable"
     >
-      <div class="rf-content">
-        <p class="rf-title">Account overview</p>
-        <p class="rf-text">
+      <div class="reflow-content">
+        <p class="reflow-title">Account overview</p>
+        <p class="reflow-text">
           Your subscription renews next month. Everything below should stay
           readable in one column, with only vertical scrolling.
         </p>
-        <ul class="rf-stats">
-          <li v-for="stat in stats" :key="stat.label" class="rf-stat">
-            <span class="rf-stat-value">{{ stat.value }}</span>
-            <span class="rf-stat-label">{{ stat.label }}</span>
+        <ul class="reflow-stats">
+          <li v-for="stat in stats" :key="stat.label" class="reflow-stat">
+            <span class="reflow-stat-value">{{ stat.value }}</span>
+            <span class="reflow-stat-label">{{ stat.label }}</span>
           </li>
         </ul>
       </div>
@@ -46,17 +46,17 @@ const stats = [
 
 <style scoped lang="scss">
 @layer components {
-  .rf-demo {
+  .reflow-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .rf-caption {
+  .reflow-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .rf-viewport {
+  .reflow-viewport {
     /* Fixed, phone-narrow stage. overflow:auto keeps any overflow local. */
     inline-size: min(100%, 21rem);
     max-block-size: 15rem;
@@ -74,7 +74,7 @@ const stats = [
     }
   }
 
-  .rf-content {
+  .reflow-content {
     /* Compliant: the content is fluid and never forced wider than the
        viewport — the same intrinsic approach used across this project. */
     display: grid;
@@ -82,17 +82,17 @@ const stats = [
     padding: var(--space-3);
   }
 
-  .rf-title {
+  .reflow-title {
     font-size: var(--text-lg);
     font-weight: 600;
   }
 
-  .rf-text {
+  .reflow-text {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .rf-stats {
+  .reflow-stats {
     /* auto-fit + min() reflows from a row to a single column as space
        tightens — no media query, no fixed track widths. */
     display: grid;
@@ -103,7 +103,7 @@ const stats = [
     list-style: none;
   }
 
-  .rf-stat {
+  .reflow-stat {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2);
@@ -116,12 +116,12 @@ const stats = [
     }
   }
 
-  .rf-stat-value {
+  .reflow-stat-value {
     font-size: var(--text-lg);
     font-weight: 600;
   }
 
-  .rf-stat-label {
+  .reflow-stat-label {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
@@ -131,15 +131,15 @@ const stats = [
      in two dimensions — exactly what 1.4.10 forbids. Only the sizing
      changes; the content and structure are identical. */
   .is-broken {
-    .rf-content {
+    .reflow-content {
       inline-size: 34rem;
     }
 
-    .rf-text {
+    .reflow-text {
       white-space: nowrap;
     }
 
-    .rf-stats {
+    .reflow-stats {
       grid-template-columns: repeat(3, 11rem);
     }
   }

--- a/src/criteria/demos/TargetSizeDemo.vue
+++ b/src/criteria/demos/TargetSizeDemo.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="ts-demo" :class="{ 'is-broken': broken }">
-    <p class="ts-caption">
+  <div class="target-size-demo" :class="{ 'is-broken': broken }">
+    <p class="target-size-caption">
       A formatting toolbar — toggle each control. With the rule off, the
       same buttons shrink and crowd together: try hitting them now.
     </p>
-    <div class="ts-toolbar" role="group" aria-label="Text formatting">
+    <div class="target-size-toolbar" role="group" aria-label="Text formatting">
       <button
         v-for="tool in tools"
         :key="tool.id"
         type="button"
-        class="ts-btn"
+        class="target-size-btn"
         :class="{ 'is-active': active[tool.id] }"
         :aria-pressed="active[tool.id] ? 'true' : 'false'"
         :aria-label="tool.label"
@@ -41,23 +41,23 @@ const active = reactive({})
 
 <style scoped lang="scss">
 @layer components {
-  .ts-demo {
+  .target-size-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .ts-caption {
+  .target-size-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .ts-toolbar {
+  .target-size-toolbar {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
   }
 
-  .ts-btn {
+  .target-size-btn {
     /* Compliant: 44px here (the 2.5.5 AAA / platform best practice; the
        2.5.8 AA floor is 24px), with real spacing between targets. */
     display: inline-flex;
@@ -97,11 +97,11 @@ const active = reactive({})
      targets become cramped and easy to mis-tap. Nothing else changes —
      the buttons keep their labels and semantics; only 2.5.8 is violated. */
   .is-broken {
-    .ts-toolbar {
+    .target-size-toolbar {
       gap: 0;
     }
 
-    .ts-btn {
+    .target-size-btn {
       min-inline-size: 16px;
       min-block-size: 16px;
       padding: 0;

--- a/src/showcases/demos/ContainerCardDemo.vue
+++ b/src/showcases/demos/ContainerCardDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="cq-demo">
-    <label class="cq-demo-control">
+  <div class="container-query">
+    <label class="container-query-control">
       Container width
       <input
         v-model="width"
@@ -16,7 +16,7 @@
          (keyboard-accessible, unlike a CSS resize handle), so you can
          watch the cards respond to their container — the viewport never
          changes. -->
-    <div class="cq-demo-stage" :style="{ inlineSize: `${width}%` }">
+    <div class="container-query-stage" :style="{ inlineSize: `${width}%` }">
       <!-- The wrapper is the container, the card inside responds to it.
            A container can't query itself — only its descendants can. -->
       <div v-for="card in cards" :key="card.title" class="card-cell">
@@ -55,12 +55,12 @@ const cards = [
 
 <style scoped lang="scss">
 @layer components {
-  .cq-demo {
+  .container-query {
     display: grid;
     gap: var(--space-4);
   }
 
-  .cq-demo-control {
+  .container-query-control {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -73,7 +73,7 @@ const cards = [
     }
   }
 
-  .cq-demo-stage {
+  .container-query-stage {
     /* The intrinsic half of the pattern: columns appear and disappear
        based on available space — no breakpoints involved. */
     display: grid;

--- a/src/showcases/demos/ContrastColorDemo.vue
+++ b/src/showcases/demos/ContrastColorDemo.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="cc-demo">
-    <label class="cc-control">
+  <div class="contrast-color-demo">
+    <label class="contrast-color-control">
       Pick a background
       <input v-model="bg" type="color" />
     </label>
 
-    <p class="cc-swatch" :style="{ '--swatch-bg': bg }">
+    <p class="contrast-color-swatch" :style="{ '--swatch-bg': bg }">
       The browser picks this text color for contrast.
     </p>
   </div>
@@ -19,13 +19,13 @@ const bg = ref('#2563eb')
 
 <style scoped lang="scss">
 @layer components {
-  .cc-demo {
+  .contrast-color-demo {
     display: grid;
     gap: var(--space-3);
     justify-items: start;
   }
 
-  .cc-control {
+  .contrast-color-control {
     display: flex;
     align-items: center;
     gap: var(--space-3);
@@ -41,7 +41,7 @@ const bg = ref('#2563eb')
     }
   }
 
-  .cc-swatch {
+  .contrast-color-swatch {
     padding: var(--space-3) var(--space-4);
     border-radius: var(--radius-md);
     background-color: var(--swatch-bg);

--- a/src/showcases/demos/DialogPolishDemo.vue
+++ b/src/showcases/demos/DialogPolishDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="dp-demo">
-    <p class="dp-caption">
+  <div class="dialog-demo">
+    <p class="dialog-caption">
       Two newer platform niceties for overlays. A <code>popover="hint"</code>
       <strong>toggletip</strong> — click the “?”, and showing, dismissing, and
       top-layer rendering are free. And a <code>&lt;dialog closedby="none"&gt;</code>
@@ -9,17 +9,17 @@
       trap to avoid). Styling reacts to the new <code>:open</code> pseudo-class.
     </p>
 
-    <div class="dp-row">
-      <span class="dp-tip-wrap">
+    <div class="dialog-row">
+      <span class="dialog-tip-wrap">
         <button
           type="button"
-          class="dp-tip-btn"
+          class="dialog-tip-btn"
           :popovertarget="tipId"
           aria-label="What does closedby do?"
         >
           ?
         </button>
-        <div :id="tipId" popover="hint" role="status" class="dp-tip">
+        <div :id="tipId" popover="hint" role="status" class="dialog-tip">
           <code>closedby</code> sets how a dialog can be dismissed:
           <code>any</code> (click-outside + Esc), <code>closerequest</code>
           (Esc only), or <code>none</code> (neither — code must close it).
@@ -31,14 +31,14 @@
       </AppButton>
     </div>
 
-    <dialog ref="dlg" closedby="none" class="dp-dialog">
-      <h4 class="dp-dialog-title">One quick decision</h4>
-      <p class="dp-dialog-text">
+    <dialog ref="dlg" closedby="none" class="dialog-dialog">
+      <h4 class="dialog-dialog-title">One quick decision</h4>
+      <p class="dialog-dialog-text">
         This dialog uses <code>closedby="none"</code>, so <kbd>Esc</kbd> and
         clicking the backdrop do nothing — you have to choose. Reserve this for
         moments where a choice is genuinely required; normally let people out.
       </p>
-      <div class="dp-dialog-actions">
+      <div class="dialog-dialog-actions">
         <AppButton variant="secondary" @click="dlg?.close()">Not now</AppButton>
         <AppButton variant="primary" @click="dlg?.close()">Got it</AppButton>
       </div>
@@ -57,28 +57,28 @@ const dlg = ref<HTMLDialogElement | null>(null)
 
 <style scoped lang="scss">
 @layer components {
-  .dp-demo {
+  .dialog-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .dp-caption {
+  .dialog-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .dp-row {
+  .dialog-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-3);
   }
 
-  .dp-tip-wrap {
+  .dialog-tip-wrap {
     display: inline-flex;
   }
 
-  .dp-tip-btn {
+  .dialog-tip-btn {
     inline-size: 2rem;
     block-size: 2rem;
     border: 1px solid var(--color-border);
@@ -88,7 +88,7 @@ const dlg = ref<HTMLDialogElement | null>(null)
     font: inherit;
     font-weight: 700;
     cursor: pointer;
-    anchor-name: --dp-tip-anchor;
+    anchor-name: --dialog-tip-anchor;
 
     @include can-hover {
       &:hover {
@@ -101,7 +101,7 @@ const dlg = ref<HTMLDialogElement | null>(null)
     }
   }
 
-  .dp-tip {
+  .dialog-tip {
     max-inline-size: 30ch;
     padding: var(--space-3);
     border: 1px solid var(--color-border);
@@ -114,7 +114,7 @@ const dlg = ref<HTMLDialogElement | null>(null)
        to the UA-centered popover (margin: auto, restored in the reset). */
     @supports (anchor-name: --a) {
       position: fixed;
-      position-anchor: --dp-tip-anchor;
+      position-anchor: --dialog-tip-anchor;
       position-area: block-end span-inline-end;
       inset: auto;
       position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
@@ -126,7 +126,7 @@ const dlg = ref<HTMLDialogElement | null>(null)
     }
   }
 
-  .dp-dialog {
+  .dialog-dialog {
     max-inline-size: 38ch;
     padding: var(--space-6);
     border: 1px solid var(--color-border);
@@ -159,18 +159,18 @@ const dlg = ref<HTMLDialogElement | null>(null)
     }
   }
 
-  .dp-dialog-title {
+  .dialog-dialog-title {
     margin-block-end: var(--space-2);
     font-size: var(--text-lg);
     font-weight: 700;
   }
 
-  .dp-dialog-text {
+  .dialog-dialog-text {
     margin-block-end: var(--space-4);
     color: var(--color-text-subtle);
   }
 
-  .dp-dialog-actions {
+  .dialog-dialog-actions {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;

--- a/src/showcases/demos/FieldSizingDemo.vue
+++ b/src/showcases/demos/FieldSizingDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="fs-demo">
-    <p class="fs-caption">
+  <div class="field-sizing-demo">
+    <p class="field-sizing-caption">
       <code>field-sizing: content</code> lets a textarea grow and shrink with
       what you type — no <code>scrollHeight</code> measuring, no resize
       listeners, no JS at all. Type a few lines: it tracks the content between
@@ -8,17 +8,17 @@
       <code>rows</code> box you can drag to resize.
     </p>
 
-    <label class="fs-field">
-      <span class="fs-label">Your note</span>
+    <label class="field-sizing-field">
+      <span class="field-sizing-label">Your note</span>
       <textarea
         v-model="text"
-        class="fs-input"
+        class="field-sizing-input"
         rows="2"
         placeholder="Start typing — the box follows along…"
       ></textarea>
     </label>
 
-    <p class="fs-hint">
+    <p class="field-sizing-hint">
       {{ text.length }} characters · grows to a max of about 8 lines, then
       scrolls.
     </p>
@@ -33,27 +33,27 @@ const text = ref('')
 
 <style scoped lang="scss">
 @layer components {
-  .fs-demo {
+  .field-sizing-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .fs-caption {
+  .field-sizing-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .fs-field {
+  .field-sizing-field {
     display: grid;
     gap: var(--space-2);
   }
 
-  .fs-label {
+  .field-sizing-label {
     font-size: var(--text-sm);
     font-weight: 600;
   }
 
-  .fs-input {
+  .field-sizing-input {
     inline-size: 100%;
     padding: var(--space-3);
     border: 1px solid var(--color-border);
@@ -78,7 +78,7 @@ const text = ref('')
     }
   }
 
-  .fs-hint {
+  .field-sizing-hint {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/HasSelectorDemo.vue
+++ b/src/showcases/demos/HasSelectorDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="sel">
-    <p class="sel-caption">
+  <div class="selector">
+    <p class="selector-caption">
       Tick a row: <code>.row:has(:checked)</code> styles the row from its
       checkbox's <em>checked</em> state — something no upward selector can do,
       and unlike <code>:focus-within</code> the highlight <em>persists</em>
@@ -8,16 +8,16 @@
       — the lighter, right tool for that job. Two states, two selectors.
     </p>
 
-    <ul class="sel-list">
-      <li v-for="task in tasks" :key="task" class="sel-row">
-        <label class="sel-label">
+    <ul class="selector-list">
+      <li v-for="task in tasks" :key="task" class="selector-row">
+        <label class="selector-label">
           <input v-model="selected" type="checkbox" :value="task" />
           <span>{{ task }}</span>
         </label>
       </li>
     </ul>
 
-    <p class="sel-count" role="status">{{ selected.length }} selected</p>
+    <p class="selector-count" role="status">{{ selected.length }} selected</p>
   </div>
 </template>
 
@@ -35,17 +35,17 @@ const selected = ref<string[]>([])
 
 <style scoped lang="scss">
 @layer components {
-  .sel {
+  .selector {
     display: grid;
     gap: var(--space-4);
   }
 
-  .sel-caption {
+  .selector-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .sel-list {
+  .selector-list {
     display: grid;
     gap: var(--space-2);
     max-inline-size: 30rem;
@@ -54,7 +54,7 @@ const selected = ref<string[]>([])
     list-style: none;
   }
 
-  .sel-row {
+  .selector-row {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
     transition:
@@ -80,7 +80,7 @@ const selected = ref<string[]>([])
     }
   }
 
-  .sel-label {
+  .selector-label {
     display: flex;
     align-items: center;
     gap: var(--space-3);
@@ -88,7 +88,7 @@ const selected = ref<string[]>([])
     cursor: pointer;
   }
 
-  .sel-count {
+  .selector-count {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);

--- a/src/showcases/demos/HighlightApiDemo.vue
+++ b/src/showcases/demos/HighlightApiDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="hl-demo">
-    <p class="hl-caption">
+  <div class="highlight-demo">
+    <p class="highlight-caption">
       The <strong>CSS Custom Highlight API</strong> paints ranges of text from
       JavaScript — <code>::highlight()</code> styled in CSS, no wrapper
       <code>&lt;span&gt;</code>s injected. Type below to highlight live matches:
@@ -8,18 +8,18 @@
       only — never the sole way meaning is conveyed).
     </p>
 
-    <label class="hl-field">
-      <span class="hl-label">Find in text</span>
+    <label class="highlight-field">
+      <span class="highlight-label">Find in text</span>
       <input
         v-model="query"
-        class="hl-input"
+        class="highlight-input"
         type="search"
         placeholder="Try “access”…"
         :disabled="!supported"
       />
     </label>
 
-    <p ref="prose" class="hl-prose">
+    <p ref="prose" class="highlight-prose">
       Accessibility is the practice of making content usable by the widest
       possible range of people. An accessible interface does not depend on one
       sense or one input device: it stays operable by keyboard, readable by
@@ -28,7 +28,7 @@
       robust, and simply more accessible than bolting it on at the end.
     </p>
 
-    <p class="hl-status" role="status">
+    <p class="highlight-status" role="status">
       <template v-if="!supported">
         Your browser doesn’t support the Custom Highlight API yet — the text
         above is unchanged and fully readable.
@@ -84,27 +84,27 @@ watch(query, update)
 
 <style scoped lang="scss">
 @layer components {
-  .hl-demo {
+  .highlight-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .hl-caption {
+  .highlight-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .hl-field {
+  .highlight-field {
     display: grid;
     gap: var(--space-2);
   }
 
-  .hl-label {
+  .highlight-label {
     font-size: var(--text-sm);
     font-weight: 600;
   }
 
-  .hl-input {
+  .highlight-input {
     inline-size: 100%;
     max-inline-size: 22rem;
     padding: var(--space-2) var(--space-3);
@@ -119,12 +119,12 @@ watch(query, update)
     }
   }
 
-  .hl-prose {
+  .highlight-prose {
     max-inline-size: 65ch;
     line-height: var(--leading-normal);
   }
 
-  .hl-status {
+  .highlight-status {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/PopoverMenuDemo.vue
+++ b/src/showcases/demos/PopoverMenuDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="pop-demo">
-    <p class="pop-caption">
+  <div class="popover-demo">
+    <p class="popover-caption">
       A real actions menu built on the <code>popover</code> attribute. The
       trigger and panel are wired by id alone — and the platform hands you
       <strong>Esc-to-close</strong>, <strong>click-outside (light)
@@ -11,34 +11,34 @@
       <code>popovertargetaction="hide"</code>.
     </p>
 
-    <div class="pop-bar">
+    <div class="popover-bar">
       <button
         type="button"
-        class="pop-trigger"
+        class="popover-trigger"
         :popovertarget="menuId"
       >
         Actions
-        <span class="pop-chevron" aria-hidden="true">▾</span>
+        <span class="popover-chevron" aria-hidden="true">▾</span>
       </button>
 
-      <div :id="menuId" popover class="pop-menu" role="menu">
+      <div :id="menuId" popover class="popover-menu" role="menu">
         <button
           v-for="item in items"
           :key="item.label"
           type="button"
-          class="pop-item"
+          class="popover-item"
           role="menuitem"
           :popovertarget="menuId"
           popovertargetaction="hide"
           @click="chosen = item.label"
         >
-          <span class="pop-item-icon" aria-hidden="true">{{ item.icon }}</span>
+          <span class="popover-item-icon" aria-hidden="true">{{ item.icon }}</span>
           {{ item.label }}
         </button>
       </div>
     </div>
 
-    <p class="pop-status" role="status">
+    <p class="popover-status" role="status">
       {{ chosen ? `You chose: ${chosen}` : 'No action chosen yet.' }}
     </p>
   </div>
@@ -60,17 +60,17 @@ const items = [
 
 <style scoped lang="scss">
 @layer components {
-  .pop-demo {
+  .popover-demo {
     display: grid;
     gap: var(--space-3);
   }
 
-  .pop-caption {
+  .popover-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .pop-trigger {
+  .popover-trigger {
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
@@ -82,8 +82,8 @@ const items = [
     font: inherit;
     font-weight: 600;
     cursor: pointer;
-    /* The element the menu tethers to (see .pop-menu). */
-    anchor-name: --pop-menu-anchor;
+    /* The element the menu tethers to (see .popover-menu). */
+    anchor-name: --popover-menu-anchor;
 
     @include can-hover {
       &:hover {
@@ -96,11 +96,11 @@ const items = [
     }
   }
 
-  .pop-chevron {
+  .popover-chevron {
     font-size: var(--text-sm);
   }
 
-  .pop-menu {
+  .popover-menu {
     min-inline-size: 12rem;
     padding: var(--space-1);
     border: 1px solid var(--color-border);
@@ -116,7 +116,7 @@ const items = [
          relative), so the menu never overflows the viewport edge and the
          flip fallbacks never fire. Fixed resolves against the viewport. */
       position: fixed;
-      position-anchor: --pop-menu-anchor;
+      position-anchor: --popover-menu-anchor;
       /* Drop below the trigger, aligned to its inline-start edge. */
       position-area: block-end span-inline-end;
       /* Clear the UA centering (inset: 0; margin: auto) so the anchor wins. */
@@ -153,7 +153,7 @@ const items = [
     }
   }
 
-  .pop-item {
+  .popover-item {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -174,12 +174,12 @@ const items = [
     }
   }
 
-  .pop-item-icon {
+  .popover-item-icon {
     inline-size: 1.25rem;
     text-align: center;
   }
 
-  .pop-status {
+  .popover-status {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/ScrollStateDemo.vue
+++ b/src/showcases/demos/ScrollStateDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="sst-demo">
-    <p class="sst-caption">
+  <div class="scroll-state-demo">
+    <p class="scroll-state-caption">
       <code>scroll-state()</code> container queries let an element restyle
       itself based on <em>how it sits in a scroller</em> — no scroll listeners,
       no JS. Here a card knows when it’s the <strong>snapped</strong> one, and a
@@ -9,22 +9,22 @@
     </p>
 
     <!-- snapped: the centered card highlights itself -->
-    <section class="sst-block">
-      <h4 class="sst-h">Snapped</h4>
+    <section class="scroll-state-block">
+      <h4 class="scroll-state-h">Snapped</h4>
       <!-- Region wraps the list so the cards keep list semantics (a
            role="region" directly on the <ul> would strip them). -->
       <div
-        class="sst-track"
+        class="scroll-state-track"
         tabindex="0"
         role="region"
         aria-label="Steps, scrollable — the centered card is highlighted"
       >
-        <ul class="sst-cards" role="list">
-          <li v-for="step in steps" :key="step.n" class="sst-card">
-            <div class="sst-card-inner">
-              <span class="sst-n">{{ step.n }}</span>
-              <span class="sst-label">{{ step.label }}</span>
-              <span class="sst-snapped" aria-hidden="true">snapped</span>
+        <ul class="scroll-state-cards" role="list">
+          <li v-for="step in steps" :key="step.n" class="scroll-state-card">
+            <div class="scroll-state-card-inner">
+              <span class="scroll-state-n">{{ step.n }}</span>
+              <span class="scroll-state-label">{{ step.label }}</span>
+              <span class="scroll-state-snapped" aria-hidden="true">snapped</span>
             </div>
           </li>
         </ul>
@@ -32,21 +32,21 @@
     </section>
 
     <!-- stuck: the sticky header restyles once it pins -->
-    <section class="sst-block">
-      <h4 class="sst-h">Stuck</h4>
+    <section class="scroll-state-block">
+      <h4 class="scroll-state-h">Stuck</h4>
       <div
-        class="sst-scroll"
+        class="scroll-state-scroll"
         tabindex="0"
         role="region"
         aria-label="List with a sticky header — scroll to pin it"
       >
-        <div class="sst-stick">
-          <div class="sst-stick-inner">
+        <div class="scroll-state-stick">
+          <div class="scroll-state-stick-inner">
             <span>Pinned header</span>
-            <span class="sst-stuck-badge" aria-hidden="true">stuck</span>
+            <span class="scroll-state-stuck-badge" aria-hidden="true">stuck</span>
           </div>
         </div>
-        <ul class="sst-list">
+        <ul class="scroll-state-list">
           <li v-for="row in rows" :key="row">Row {{ row }}</li>
         </ul>
       </div>
@@ -67,29 +67,29 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
 
 <style scoped lang="scss">
 @layer components {
-  .sst-demo {
+  .scroll-state-demo {
     display: grid;
     gap: var(--space-4);
   }
 
-  .sst-caption {
+  .scroll-state-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .sst-block {
+  .scroll-state-block {
     display: grid;
     gap: var(--space-2);
   }
 
-  .sst-h {
+  .scroll-state-h {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
   }
 
   /* ---- Snapped carousel ---- */
-  .sst-track {
+  .scroll-state-track {
     padding: var(--space-2);
     overflow-x: auto;
     scroll-snap-type: x mandatory;
@@ -101,7 +101,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     }
   }
 
-  .sst-cards {
+  .scroll-state-cards {
     display: flex;
     gap: var(--space-3);
     margin: 0;
@@ -109,7 +109,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     list-style: none;
   }
 
-  .sst-card {
+  .scroll-state-card {
     flex: 0 0 min(60%, 13rem);
     scroll-snap-align: center;
     /* The card becomes a scroll-state query container; its inner content
@@ -117,7 +117,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     container-type: scroll-state;
   }
 
-  .sst-card-inner {
+  .scroll-state-card-inner {
     display: grid;
     gap: var(--space-1);
     block-size: 100%;
@@ -135,18 +135,18 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     }
   }
 
-  .sst-n {
+  .scroll-state-n {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .sst-label {
+  .scroll-state-label {
     font-weight: 600;
   }
 
   /* Badge hidden until the card is snapped (revealed in the query below). */
-  .sst-snapped {
+  .scroll-state-snapped {
     inline-size: fit-content;
     margin-block-start: var(--space-1);
     padding: 0 var(--space-2);
@@ -160,20 +160,20 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
 
   @supports (container-type: scroll-state) {
     @container scroll-state(snapped: inline) {
-      .sst-card-inner {
+      .scroll-state-card-inner {
         border-color: var(--color-primary);
         box-shadow: var(--shadow-md);
         scale: 1.03;
       }
 
-      .sst-snapped {
+      .scroll-state-snapped {
         opacity: 1;
       }
     }
   }
 
   /* ---- Stuck sticky header ---- */
-  .sst-scroll {
+  .scroll-state-scroll {
     block-size: 12rem;
     overflow-y: auto;
     border: 1px solid var(--color-border);
@@ -185,7 +185,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     }
   }
 
-  .sst-stick {
+  .scroll-state-stick {
     position: sticky;
     inset-block-start: 0;
     /* The sticky element is the scroll-state container; its inner header
@@ -193,7 +193,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     container-type: scroll-state;
   }
 
-  .sst-stick-inner {
+  .scroll-state-stick-inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -206,7 +206,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
       background-color var(--duration-normal) var(--easing-standard);
   }
 
-  .sst-stuck-badge {
+  .scroll-state-stuck-badge {
     padding: 0 var(--space-2);
     border-radius: var(--radius-full);
     background-color: var(--color-bg-subtle);
@@ -217,7 +217,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
 
   @supports (container-type: scroll-state) {
     @container scroll-state(stuck: top) {
-      .sst-stick-inner {
+      .scroll-state-stick-inner {
         background-color: var(--color-surface-glass);
         backdrop-filter: blur(8px);
         box-shadow: var(--shadow-md);
@@ -228,13 +228,13 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
         }
       }
 
-      .sst-stuck-badge {
+      .scroll-state-stuck-badge {
         opacity: 1;
       }
     }
   }
 
-  .sst-list {
+  .scroll-state-list {
     display: grid;
     gap: 1px;
     margin: 0;
@@ -242,7 +242,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
     list-style: none;
   }
 
-  .sst-list li {
+  .scroll-state-list li {
     padding: var(--space-2) var(--space-3);
     font-size: var(--text-sm);
   }

--- a/src/showcases/demos/SlidingIndicatorDemo.vue
+++ b/src/showcases/demos/SlidingIndicatorDemo.vue
@@ -8,11 +8,11 @@
       arrow-key navigable and announced as a radio group.
     </p>
 
-    <fieldset class="seg">
+    <fieldset class="segmented">
       <legend class="visually-hidden">Choose a view</legend>
-      <div class="seg-track" :style="{ '--n': options.length }">
-        <span class="seg-indicator" aria-hidden="true"></span>
-        <label v-for="opt in options" :key="opt" class="seg-opt">
+      <div class="segmented-track" :style="{ '--n': options.length }">
+        <span class="segmented-indicator" aria-hidden="true"></span>
+        <label v-for="opt in options" :key="opt" class="segmented-opt">
           <input
             v-model="view"
             type="radio"
@@ -20,7 +20,7 @@
             :value="opt"
             class="visually-hidden"
           />
-          <span class="seg-label">{{ opt }}</span>
+          <span class="segmented-label">{{ opt }}</span>
         </label>
       </div>
     </fieldset>
@@ -47,13 +47,13 @@ const view = ref(options[0])
     color: var(--color-text-subtle);
   }
 
-  .seg {
+  .segmented {
     margin: 0;
     padding: 0;
     border: 0;
   }
 
-  .seg-track {
+  .segmented-track {
     position: relative;
     display: grid;
     grid-template-columns: repeat(var(--n), 1fr);
@@ -72,7 +72,7 @@ const view = ref(options[0])
      i × 100% steps it from option to option. The transition uses a motion
      token, which preferences.css zeroes under reduced motion — so the slide
      becomes an instant jump with no per-component override. */
-  .seg-indicator {
+  .segmented-indicator {
     position: absolute;
     z-index: 0;
     inset-block: var(--space-1);
@@ -90,12 +90,12 @@ const view = ref(options[0])
   }
 
   /* :has() maps the checked radio to the indicator's slot index. */
-  .seg-track:has(.seg-opt:nth-of-type(1) input:checked) { --i: 0; }
-  .seg-track:has(.seg-opt:nth-of-type(2) input:checked) { --i: 1; }
-  .seg-track:has(.seg-opt:nth-of-type(3) input:checked) { --i: 2; }
-  .seg-track:has(.seg-opt:nth-of-type(4) input:checked) { --i: 3; }
+  .segmented-track:has(.segmented-opt:nth-of-type(1) input:checked) { --i: 0; }
+  .segmented-track:has(.segmented-opt:nth-of-type(2) input:checked) { --i: 1; }
+  .segmented-track:has(.segmented-opt:nth-of-type(3) input:checked) { --i: 2; }
+  .segmented-track:has(.segmented-opt:nth-of-type(4) input:checked) { --i: 3; }
 
-  .seg-opt {
+  .segmented-opt {
     position: relative;
     z-index: 1;
     display: grid;
@@ -112,7 +112,7 @@ const view = ref(options[0])
     }
   }
 
-  .seg-label {
+  .segmented-label {
     font-size: var(--text-sm);
     font-weight: 500;
     color: var(--color-text-subtle);
@@ -120,7 +120,7 @@ const view = ref(options[0])
 
   /* The selected option's label firms up — state isn't carried by the pill
      position alone. */
-  .seg-opt:has(input:checked) .seg-label {
+  .segmented-opt:has(input:checked) .segmented-label {
     font-weight: 600;
     color: var(--color-text);
   }

--- a/src/showcases/demos/StartingStyleDemo.vue
+++ b/src/showcases/demos/StartingStyleDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="ss-demo">
-    <p class="ss-caption">
+  <div class="starting-style-demo">
+    <p class="starting-style-caption">
       <code>@starting-style</code> animates an element <em>in</em> from
       <code>display: none</code> — entry transitions that used to need JS.
       Exit is handled by <code>transition-behavior: allow-discrete</code>.
@@ -11,15 +11,15 @@
     <AppButton
       variant="secondary"
       :aria-expanded="open"
-      aria-controls="ss-card"
+      aria-controls="starting-style-card"
       @click="open = !open"
     >
       {{ open ? 'Hide' : 'Show' }} card
     </AppButton>
 
-    <div id="ss-card" class="ss-card" :class="{ 'is-open': open }">
-      <p class="ss-card-title">Hello there 👋</p>
-      <p class="ss-card-text">
+    <div id="starting-style-card" class="starting-style-card" :class="{ 'is-open': open }">
+      <p class="starting-style-card-title">Hello there 👋</p>
+      <p class="starting-style-card-text">
         I faded and slid in from <code>display: none</code> — no JS animation,
         just <code>@starting-style</code> plus a transition.
       </p>
@@ -37,18 +37,18 @@ const open = ref(false)
 
 <style scoped lang="scss">
 @layer components {
-  .ss-demo {
+  .starting-style-demo {
     display: grid;
     gap: var(--space-3);
     justify-items: start;
   }
 
-  .ss-caption {
+  .starting-style-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .ss-card {
+  .starting-style-card {
     /* Closed state: removed from layout and the a11y tree. */
     display: none;
     max-inline-size: 40ch;
@@ -83,11 +83,11 @@ const open = ref(false)
     }
   }
 
-  .ss-card-title {
+  .starting-style-card-title {
     font-weight: 600;
   }
 
-  .ss-card-text {
+  .starting-style-card-text {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/StyleQueryCuesDemo.vue
+++ b/src/showcases/demos/StyleQueryCuesDemo.vue
@@ -18,12 +18,12 @@
     <!-- No JS: --cues is set on the demo root in CSS, where :has() reads this
          checkbox. It inherits down to each status, where the style query reads
          it and adds shapes to statuses that don't know about it. -->
-    <ul class="srv-list">
-      <li v-for="s in services" :key="s.name" class="srv">
-        <span class="srv-name">{{ s.name }}</span>
+    <ul class="service-list">
+      <li v-for="s in services" :key="s.name" class="service">
+        <span class="service-name">{{ s.name }}</span>
         <span
-          class="srv-status"
-          :class="`srv-status--${s.state}`"
+          class="service-status"
+          :class="`service-status--${s.state}`"
           role="img"
           :aria-label="stateLabel[s.state]"
         ></span>
@@ -79,7 +79,7 @@ const services: { name: string; state: State }[] = [
     cursor: pointer;
   }
 
-  .srv-list {
+  .service-list {
     display: grid;
     gap: var(--space-2);
     margin: 0;
@@ -87,7 +87,7 @@ const services: { name: string; state: State }[] = [
     list-style: none;
   }
 
-  .srv {
+  .service {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -102,7 +102,7 @@ const services: { name: string; state: State }[] = [
     }
   }
 
-  .srv-status {
+  .service-status {
     display: grid;
     place-items: center;
     inline-size: 1.25rem;
@@ -132,7 +132,7 @@ const services: { name: string; state: State }[] = [
      survives any color-vision deficiency. No status element references
      --cues; the query reaches them from their ancestor. */
   @container style(--cues: on) {
-    .srv-status {
+    .service-status {
       background-color: transparent;
       color: var(--state-color);
 

--- a/src/showcases/demos/SubgridDemo.vue
+++ b/src/showcases/demos/SubgridDemo.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="sg-grid">
-    <article v-for="card in cards" :key="card.title" class="sg-card">
-      <h5 class="sg-title">{{ card.title }}</h5>
-      <p class="sg-text">{{ card.text }}</p>
-      <p class="sg-meta">{{ card.meta }}</p>
+  <div class="subgrid-grid">
+    <article v-for="card in cards" :key="card.title" class="subgrid-card">
+      <h5 class="subgrid-title">{{ card.title }}</h5>
+      <p class="subgrid-text">{{ card.text }}</p>
+      <p class="subgrid-meta">{{ card.meta }}</p>
     </article>
   </div>
 </template>
@@ -32,13 +32,13 @@ const cards = [
 
 <style scoped lang="scss">
 @layer components {
-  .sg-grid {
+  .subgrid-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 10rem), 1fr));
     gap: var(--space-3);
   }
 
-  .sg-card {
+  .subgrid-card {
     display: grid;
     /* Each card spans three of the parent grid's rows and adopts them, so
        title/text/meta line up ACROSS cards regardless of content length.
@@ -57,16 +57,16 @@ const cards = [
     }
   }
 
-  .sg-title {
+  .subgrid-title {
     font-size: var(--text-base);
   }
 
-  .sg-text {
+  .subgrid-text {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .sg-meta {
+  .subgrid-meta {
     align-self: end;
     font-size: var(--text-sm);
     font-weight: 600;

--- a/src/showcases/demos/TextWrapDemo.vue
+++ b/src/showcases/demos/TextWrapDemo.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="tw-demo">
+  <div class="text-wrap-demo">
     <!-- Two columns of the SAME text so the wrapping difference is
          visible side by side. The width is deliberately narrow to force
          ragged line breaks. -->
-    <figure class="tw-col">
-      <figcaption class="tw-label">Default wrapping</figcaption>
-      <h4 class="tw-heading">{{ heading }}</h4>
-      <p class="tw-body">{{ body }}</p>
+    <figure class="text-wrap-col">
+      <figcaption class="text-wrap-label">Default wrapping</figcaption>
+      <h4 class="text-wrap-heading">{{ heading }}</h4>
+      <p class="text-wrap-body">{{ body }}</p>
     </figure>
 
-    <figure class="tw-col">
-      <figcaption class="tw-label">
+    <figure class="text-wrap-col">
+      <figcaption class="text-wrap-label">
         <code>balance</code> + <code>pretty</code>
       </figcaption>
-      <h4 class="tw-heading tw-heading--balance">{{ heading }}</h4>
-      <p class="tw-body tw-body--pretty">{{ body }}</p>
+      <h4 class="text-wrap-heading text-wrap-heading--balance">{{ heading }}</h4>
+      <p class="text-wrap-body text-wrap-body--pretty">{{ body }}</p>
     </figure>
   </div>
 </template>
@@ -29,7 +29,7 @@ const body =
 
 <style scoped lang="scss">
 @layer components {
-  .tw-demo {
+  .text-wrap-demo {
     /* Two columns when there's room, stacked when not — no media query.
        The columns are capped (not 1fr) so the headings stay narrow enough to
        wrap on wide screens, where the balance/pretty difference is visible. */
@@ -39,7 +39,7 @@ const body =
     gap: var(--space-4);
   }
 
-  .tw-col {
+  .text-wrap-col {
     display: grid;
     gap: var(--space-2);
     margin: 0;
@@ -53,13 +53,13 @@ const body =
     }
   }
 
-  .tw-label {
+  .text-wrap-label {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
   }
 
-  .tw-heading {
+  .text-wrap-heading {
     font-size: var(--text-lg);
     line-height: var(--leading-tight);
 
@@ -70,7 +70,7 @@ const body =
     }
   }
 
-  .tw-body {
+  .text-wrap-body {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
 

--- a/src/showcases/demos/ThemePickerDemo.vue
+++ b/src/showcases/demos/ThemePickerDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="tp-demo">
-    <p class="tp-caption">
+  <div class="theme-picker-demo">
+    <p class="theme-picker-caption">
       Pick an accent and drag its lightness. The whole palette is derived from
       that one seed, and the button label is protected <strong>two ways</strong>:
       a <strong>pure-CSS clamp</strong> keeps even the plain black/white
@@ -10,15 +10,15 @@
       quietly rescues the rendered label.
     </p>
 
-    <div class="tp-grid">
-      <div class="tp-controls">
-        <label class="tp-field">
-          <span class="tp-label">
-            Accent hue <output class="tp-out">{{ pickH }}°</output>
+    <div class="theme-picker-grid">
+      <div class="theme-picker-controls">
+        <label class="theme-picker-field">
+          <span class="theme-picker-label">
+            Accent hue <output class="theme-picker-out">{{ pickH }}°</output>
           </span>
           <input
             v-model.number="pickH"
-            class="tp-range tp-hue"
+            class="theme-picker-range theme-picker-hue"
             type="range"
             min="0"
             max="360"
@@ -26,13 +26,13 @@
           />
         </label>
 
-        <label class="tp-field">
-          <span class="tp-label">
-            Accent lightness <output class="tp-out">{{ pickL }}%</output>
+        <label class="theme-picker-field">
+          <span class="theme-picker-label">
+            Accent lightness <output class="theme-picker-out">{{ pickL }}%</output>
           </span>
           <input
             v-model.number="pickL"
-            class="tp-range"
+            class="theme-picker-range"
             type="range"
             min="0"
             max="100"
@@ -40,19 +40,19 @@
           />
         </label>
 
-        <label class="tp-check">
+        <label class="theme-picker-check">
           <input v-model="bypass" type="checkbox" />
           Bypass the safety clamp
         </label>
 
-        <div class="tp-presets">
-          <span class="tp-presets-label">CVD-robust presets</span>
-          <div class="tp-chips">
+        <div class="theme-picker-presets">
+          <span class="theme-picker-presets-label">CVD-robust presets</span>
+          <div class="theme-picker-chips">
             <button
               v-for="p in presets"
               :key="p.name"
               type="button"
-              class="tp-chip"
+              class="theme-picker-chip"
               @click="apply(p)"
             >
               {{ p.name }}
@@ -65,33 +65,33 @@
            math and --seed-accent live in CSS, so the theme really is derived
            in the cascade, not in JS. -->
       <article
-        class="surface tp-preview"
+        class="surface theme-picker-preview"
         :style="{ '--pick-h': pickH, '--pick-l': pickL, '--bypass': bypass ? 1 : 0 }"
       >
         <p class="surface-title">Live preview</p>
         <p class="surface-text">Body copy and a primary action, themed from one seed.</p>
-        <div class="tp-actions">
+        <div class="theme-picker-actions">
           <AppButton variant="primary">Primary</AppButton>
           <AppButton variant="secondary">Secondary</AppButton>
         </div>
       </article>
     </div>
 
-    <dl class="tp-report" :class="{ 'is-fail': !report.fallback.passes }">
-      <div class="tp-stat">
+    <dl class="theme-picker-report" :class="{ 'is-fail': !report.fallback.passes }">
+      <div class="theme-picker-stat">
         <dt>Applied</dt>
         <dd>{{ report.appliedPct }}% L</dd>
       </div>
-      <div class="tp-stat">
+      <div class="theme-picker-stat">
         <dt>Fallback label</dt>
         <dd>{{ report.fallback.ratio }}:1 · {{ report.fallback.passes ? 'AA ✓' : 'fails AA' }}</dd>
       </div>
-      <div v-if="supportsContrastColor" class="tp-stat">
+      <div v-if="supportsContrastColor" class="theme-picker-stat">
         <dt>Rendered (<code>contrast-color</code>)</dt>
         <dd>{{ report.rendered.ratio }}:1 · {{ report.rendered.passes ? 'AA ✓' : 'fails AA' }}</dd>
       </div>
     </dl>
-    <p class="tp-note" role="status">{{ note }}</p>
+    <p class="theme-picker-note" role="status">{{ note }}</p>
   </div>
 </template>
 
@@ -146,35 +146,35 @@ const note = computed(() => {
 
 <style scoped lang="scss">
 @layer components {
-  .tp-demo {
+  .theme-picker-demo {
     display: grid;
     gap: var(--space-4);
   }
 
-  .tp-caption {
+  .theme-picker-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .tp-grid {
+  .theme-picker-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
     gap: var(--space-4);
     align-items: start;
   }
 
-  .tp-controls {
+  .theme-picker-controls {
     display: grid;
     gap: var(--space-4);
     align-content: start;
   }
 
-  .tp-field {
+  .theme-picker-field {
     display: grid;
     gap: var(--space-2);
   }
 
-  .tp-label {
+  .theme-picker-label {
     display: flex;
     justify-content: space-between;
     gap: var(--space-2);
@@ -182,19 +182,19 @@ const note = computed(() => {
     font-weight: 600;
   }
 
-  .tp-out {
+  .theme-picker-out {
     font-family: var(--font-mono);
     font-weight: 400;
     color: var(--color-text-subtle);
   }
 
-  .tp-range {
+  .theme-picker-range {
     inline-size: 100%;
     accent-color: var(--color-primary);
   }
 
   /* A hue wheel as the track — communicates what the slider controls. */
-  .tp-hue {
+  .theme-picker-hue {
     block-size: 0.5rem;
     border-radius: var(--radius-full);
     appearance: none;
@@ -214,30 +214,30 @@ const note = computed(() => {
     }
   }
 
-  .tp-check {
+  .theme-picker-check {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     font-size: var(--text-sm);
   }
 
-  .tp-presets {
+  .theme-picker-presets {
     display: grid;
     gap: var(--space-2);
   }
 
-  .tp-presets-label {
+  .theme-picker-presets-label {
     font-size: var(--text-sm);
     font-weight: 600;
   }
 
-  .tp-chips {
+  .theme-picker-chips {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
   }
 
-  .tp-chip {
+  .theme-picker-chip {
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-full);
@@ -268,7 +268,7 @@ const note = computed(() => {
        4. bypass blends back to the raw value to expose the unsafe pick.
      Overriding --seed-accent here (components layer) beats theming.css's
      default (themes layer), and the engine's derivations pick it up. */
-  .tp-preview {
+  .theme-picker-preview {
     --raw-l: calc(var(--pick-l) / 100);
     /* A big multiplier turns the sign of (0.62 − L) into a 0/1 step. */
     --is-dark: clamp(0, (0.62 - var(--raw-l)) * 100000, 1);
@@ -283,14 +283,14 @@ const note = computed(() => {
     align-content: start;
   }
 
-  .tp-actions {
+  .theme-picker-actions {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
     margin-block-start: var(--space-1);
   }
 
-  .tp-report {
+  .theme-picker-report {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2) var(--space-6);
@@ -305,7 +305,7 @@ const note = computed(() => {
     }
   }
 
-  .tp-stat {
+  .theme-picker-stat {
     display: grid;
     gap: 2px;
 
@@ -321,7 +321,7 @@ const note = computed(() => {
     }
   }
 
-  .tp-note {
+  .theme-picker-note {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/ViewTransitionDemo.vue
+++ b/src/showcases/demos/ViewTransitionDemo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="vt-demo">
-    <p class="vt-caption">
+  <div class="view-transition-demo">
+    <p class="view-transition-caption">
       Switch the layout and the cards <em>morph</em> between arrangements
       instead of snapping — the browser tweens each shared element across the
       DOM change. One <code>startViewTransition()</code> call and a
@@ -9,11 +9,11 @@
       instant and correct) and where the API isn’t supported.
     </p>
 
-    <div class="vt-bar">
-      <div class="vt-toggle" role="group" aria-label="Layout">
+    <div class="view-transition-bar">
+      <div class="view-transition-toggle" role="group" aria-label="Layout">
         <button
           type="button"
-          class="vt-btn"
+          class="view-transition-btn"
           :aria-pressed="view === 'grid'"
           @click="setView('grid')"
         >
@@ -21,7 +21,7 @@
         </button>
         <button
           type="button"
-          class="vt-btn"
+          class="view-transition-btn"
           :aria-pressed="view === 'list'"
           @click="setView('list')"
         >
@@ -30,15 +30,15 @@
       </div>
     </div>
 
-    <ul class="vt-items" :class="`vt-items-${view}`" role="list">
+    <ul class="view-transition-items" :class="`view-transition-items-${view}`" role="list">
       <li
         v-for="item in items"
         :key="item.id"
-        class="vt-item"
-        :style="{ viewTransitionName: `vt-${item.id}` }"
+        class="view-transition-item"
+        :style="{ viewTransitionName: `view-transition-${item.id}` }"
       >
-        <span class="vt-item-icon" aria-hidden="true">{{ item.icon }}</span>
-        <span class="vt-item-label">{{ item.label }}</span>
+        <span class="view-transition-item-icon" aria-hidden="true">{{ item.icon }}</span>
+        <span class="view-transition-item-label">{{ item.label }}</span>
       </li>
     </ul>
   </div>
@@ -85,17 +85,17 @@ function setView(next: View) {
 
 <style scoped lang="scss">
 @layer components {
-  .vt-demo {
+  .view-transition-demo {
     display: grid;
     gap: var(--space-4);
   }
 
-  .vt-caption {
+  .view-transition-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }
 
-  .vt-toggle {
+  .view-transition-toggle {
     display: inline-flex;
     gap: var(--space-1);
     padding: var(--space-1);
@@ -104,7 +104,7 @@ function setView(next: View) {
     background-color: var(--color-bg-subtle);
   }
 
-  .vt-btn {
+  .view-transition-btn {
     padding: var(--space-2) var(--space-4);
     border: 0;
     border-radius: var(--radius-full);
@@ -133,7 +133,7 @@ function setView(next: View) {
     }
   }
 
-  .vt-items {
+  .view-transition-items {
     display: grid;
     gap: var(--space-3);
     margin: 0;
@@ -141,15 +141,15 @@ function setView(next: View) {
     list-style: none;
   }
 
-  .vt-items-grid {
+  .view-transition-items-grid {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 9rem), 1fr));
   }
 
-  .vt-items-list {
+  .view-transition-items-list {
     grid-template-columns: 1fr;
   }
 
-  .vt-item {
+  .view-transition-item {
     display: flex;
     gap: var(--space-2);
     align-items: center;
@@ -163,17 +163,17 @@ function setView(next: View) {
     }
   }
 
-  .vt-items-grid .vt-item {
+  .view-transition-items-grid .view-transition-item {
     flex-direction: column;
     text-align: center;
   }
 
-  .vt-item-icon {
+  .view-transition-item-icon {
     font-size: var(--text-2xl);
     color: var(--color-primary);
   }
 
-  .vt-item-label {
+  .view-transition-item-label {
     font-size: var(--text-sm);
     font-weight: 500;
   }

--- a/src/showcases/demos/themePickerMath.ts
+++ b/src/showcases/demos/themePickerMath.ts
@@ -5,7 +5,7 @@
  * the demo's core promise — that the lightness clamp keeps the button label at
  * WCAG AA for any hue — and that guarantee deserves a test, not just a comment.
  *
- * The clamp itself runs in CSS (see .tp-preview); this mirrors the same maths in
+ * The clamp itself runs in CSS (see .theme-picker-preview); this mirrors the same maths in
  * JS purely to compute an honest contrast read-out for the figure.
  */
 
@@ -13,7 +13,7 @@
 // (and stays mostly in sRGB gamut). Mirrors the value used in the stylesheet.
 export const CHROMA = 0.15
 // Lightness threshold the engine uses to flip the label black/white, and the
-// safe bounds the clamp snaps to. Mirrors .tp-preview in the stylesheet.
+// safe bounds the clamp snaps to. Mirrors .theme-picker-preview in the stylesheet.
 export const FLIP = 0.62
 export const DARK_MAX = 0.45 // darkest-safe ceiling for a white label
 export const LIGHT_MIN = 0.78 // lightest-safe floor for a black label

--- a/tests/e2e/inversion.spec.ts
+++ b/tests/e2e/inversion.spec.ts
@@ -22,14 +22,14 @@ test.describe('ThemePicker — the clamp guarantee, verified in a real browser',
     page,
   }) => {
     await page.goto('/')
-    await page.locator('.tp-preview').scrollIntoViewIfNeeded()
-    const readout = page.locator('.tp-note')
+    await page.locator('.theme-picker-preview').scrollIntoViewIfNeeded()
+    const readout = page.locator('.theme-picker-note')
 
     // Clamp ON (default lightness sits in the dead zone): read-out reports AA,
     // and an external auditor finds no contrast violation in the live preview.
     await expect(readout).toContainText(/meets WCAG AA|safe range/i)
     const clamped = await new AxeBuilder({ page })
-      .include('.tp-preview')
+      .include('.theme-picker-preview')
       .withRules(['color-contrast'])
       .analyze()
     expect(clamped.violations).toEqual([])


### PR DESCRIPTION
- Updated class names in HighlightApiDemo.vue, PopoverMenuDemo.vue, ScrollStateDemo.vue, SlidingIndicatorDemo.vue, StartingStyleDemo.vue, StyleQueryCuesDemo.vue, SubgridDemo.vue, TextWrapDemo.vue, ThemePickerDemo.vue, and ViewTransitionDemo.vue to follow a consistent naming convention.
- Adjusted corresponding styles in SCSS files to match the new class names.
- Modified themePickerMath.ts and e2e tests to reflect the updated class names.