### PR TITLE
fix: update heading levels for consistency across demo components; en…

### DIFF
--- a/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
+++ b/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
@@ -10,7 +10,7 @@
 
     <!-- snapped: the centered card highlights itself -->
     <section class="scroll-state-block">
-      <h4 class="scroll-state-h">Snapped</h4>
+      <h5 class="scroll-state-h">Snapped</h5>
       <!-- Region wraps the list so the cards keep list semantics (a
            role="region" directly on the <ul> would strip them). -->
       <div
@@ -33,7 +33,7 @@
 
     <!-- stuck: the sticky header restyles once it pins -->
     <section class="scroll-state-block">
-      <h4 class="scroll-state-h">Stuck</h4>
+      <h5 class="scroll-state-h">Stuck</h5>
       <div
         class="scroll-state-scroll"
         tabindex="0"

--- a/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
+++ b/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
@@ -5,7 +5,7 @@
          ragged line breaks. -->
     <figure class="text-wrap-col">
       <figcaption class="text-wrap-label">Default wrapping</figcaption>
-      <h4 class="text-wrap-heading">{{ heading }}</h4>
+      <h5 class="text-wrap-heading">{{ heading }}</h5>
       <p class="text-wrap-body">{{ body }}</p>
     </figure>
 
@@ -13,7 +13,7 @@
       <figcaption class="text-wrap-label">
         <code>balance</code> + <code>pretty</code>
       </figcaption>
-      <h4 class="text-wrap-heading text-wrap-heading--balance">{{ heading }}</h4>
+      <h5 class="text-wrap-heading text-wrap-heading--balance">{{ heading }}</h5>
       <p class="text-wrap-body text-wrap-body--pretty">{{ body }}</p>
     </figure>
   </div>

--- a/src/showcases/demos/ZoomCompareDemo/ZoomCompareDemo.vue
+++ b/src/showcases/demos/ZoomCompareDemo/ZoomCompareDemo.vue
@@ -24,9 +24,9 @@
 
     <div class="zoom-compare-panels">
       <section class="zoom-compare-panel" aria-labelledby="zoom-via-zoom">
-        <h4 id="zoom-via-zoom" class="zoom-compare-title">
+        <h5 id="zoom-via-zoom" class="zoom-compare-title">
           <code>zoom</code> — reflows
-        </h4>
+        </h5>
         <div class="zoom-compare-stage">
           <p class="zoom-compare-context">Heading above</p>
           <article class="zoom-compare-card zoom-compare-card-zoom">Magnified card</article>
@@ -35,9 +35,9 @@
       </section>
 
       <section class="zoom-compare-panel" aria-labelledby="zoom-via-scale">
-        <h4 id="zoom-via-scale" class="zoom-compare-title">
+        <h5 id="zoom-via-scale" class="zoom-compare-title">
           <code>transform: scale()</code> — overlaps
-        </h4>
+        </h5>
         <div class="zoom-compare-stage">
           <p class="zoom-compare-context">Heading above</p>
           <article class="zoom-compare-card zoom-compare-card-scale">Magnified card</article>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -89,7 +89,11 @@
 
     --color-primary:      light-dark(#2563eb, #3b82f6);
     --color-primary-hover:light-dark(#1d4ed8, #60a5fa);
-    --color-primary-text: #fff;
+    /* The label sits ON --color-primary, so it must contrast the primary itself,
+       not the page. Light-mode primary is a deep blue (white label ≈ 5.2:1); the
+       dark-mode primary is brighter, where white only reaches ~3.7:1 — below AA —
+       so the label flips dark there (≈ 5.1:1). */
+    --color-primary-text: light-dark(#fff, #111);
 
     --color-success:      light-dark(#16a34a, #4ade80);
     --color-warning:      light-dark(#d97706, #fbbf24);


### PR DESCRIPTION
…hance color contrast for primary text

## Accessibility fixes: dark-mode button contrast + heading nesting

Two small a11y corrections found during review.

**1. Dark-mode primary label meets WCAG AA.** `--color-primary-text` was hardcoded `#fff`, giving only 3.68:1 on the brighter dark-mode primary. It now adapts (`light-dark(#fff, #111)`) → 5.17:1 light / 5.13:1 dark. Darkening the primary itself wasn't an option (it's also used as link text on the dark page), so the label flips instead.

**2. Heading outline nesting.** ScrollStateDemo, ZoomCompareDemo, and TextWrapDemo rendered `<h4>` sub-labels as siblings of their showcase's `<h4>` title; changed to `<h5>` so they nest correctly. Styling keyed off classes, so appearance is unchanged.

Verified: one `<h1>`, zero heading-level skips; build + stylelint green.