### PR TITLE
style: add animations and visual interaction, AKA add some pizazz

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -35,10 +35,11 @@
              decorative, so the whole grid is aria-hidden. -->
         <div class="hero-icons" aria-hidden="true">
           <span
-            v-for="icon in heroIcons"
+            v-for="(icon, i) in heroIcons"
             :key="icon.name"
             class="hero-icon"
             :data-kind="icon.kind"
+            :style="{ '--i': i }"
           >
             <svg class="hero-icon-svg" viewBox="0 -960 960 960">
               <path :d="icon.d" />
@@ -603,6 +604,11 @@ const toc = [
     gap: var(--space-12);
     /* Keep the heading clear of the sticky spine after a fragment jump. */
     scroll-margin-block-start: var(--space-16);
+    /* Anchor + own stacking context for the giant pillar watermark
+       (PillarHeader paints a faint oversized mark at z-index -1). `isolate`
+       keeps that negative layer trapped here, above the page background. */
+    position: relative;
+    isolation: isolate;
   }
 
   .demo {
@@ -900,8 +906,9 @@ const toc = [
   .hero-icons {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: var(--space-6);
-    justify-items: center;
+    /* No grid gap: the cells tile edge-to-edge so the Dock hover target is
+       continuous — moving across the band never drops into a dead gap between
+       glyphs. The visual spacing comes from padding inside each cell instead. */
 
     @include from('md') {
       grid-template-columns: repeat(6, 1fr);
@@ -911,10 +918,126 @@ const toc = [
   .hero-icon {
     display: grid;
     place-items: center;
+    /* Padding (not gap) spaces the glyphs, so each cell is a seamless hit area
+       that fills its track. */
+    padding: var(--space-3);
     color: var(--color-text);
 
     &[data-kind='concept'] {
       color: var(--color-primary);
+    }
+
+    /* One-time staggered entrance — the band assembles itself on load. The
+       whole thing lives inside no-preference so reduced-motion users never see
+       the opacity:0 start (no flash), just the icons already in place. The
+       per-icon delay comes from the inline --i (its index). */
+    @media (prefers-reduced-motion: no-preference) {
+      animation: hero-icon-in 0.5s var(--easing-enter) both;
+      animation-delay: calc(var(--i, 0) * 45ms);
+    }
+
+    /* Only the colour transitions on the cell; the magnification lives on the
+       glyph (.hero-icon-svg) so the cell stays a fixed-size hover target.
+       Cosmetic only — the whole band is aria-hidden. */
+    @include can-hover {
+      transition: color var(--duration-fast) var(--easing-standard);
+    }
+  }
+
+  @keyframes hero-icon-in {
+    from {
+      opacity: 0;
+      transform: translateY(0.7rem);
+    }
+  }
+
+  /* One magnified glyph: the cell $offset siblings away in DOM order, walked
+     either forward ($dir: 'after', via `+`) or backward ('before', via :has()).
+     $edge suppresses the row-boundary wrap — '' for vertical neighbours (a
+     column never wraps), 'right' to skip when the hovered glyph is last in its
+     row, 'left' when it's first. So an edge glyph only reaches the siblings it
+     visually touches, not the ones that are merely adjacent in source order.
+     The scale lands on the glyph (.hero-icon-svg), never the cell. */
+  @mixin dock-cell($offset, $dir, $edge, $scale, $cols) {
+    $guard: '';
+    @if $edge == 'right' {
+      $guard: ':not(:nth-child(#{$cols}n))';
+    } @else if $edge == 'left' {
+      $guard: ':not(:nth-child(#{$cols}n + 1))';
+    }
+
+    $sel: '';
+    @if $dir == 'after' {
+      $sel: '.hero-icon:hover#{$guard}';
+      @for $i from 1 through $offset {
+        $sel: '#{$sel} + .hero-icon';
+      }
+    } @else {
+      // `1 to $offset` counts UP exactly $offset - 1 times (empty at offset 1);
+      // `through $offset - 1` would be `1 through 0`, which Sass counts DOWN.
+      $inner: '+ .hero-icon:hover#{$guard}';
+      @for $i from 1 to $offset {
+        $inner: '+ .hero-icon #{$inner}';
+      }
+
+      $sel: '.hero-icon:has(#{$inner})';
+    }
+
+    #{$sel} .hero-icon-svg {
+      scale: $scale;
+    }
+  }
+
+  /* The 2D bulge for a grid of $cols columns. Grid geometry maps onto DOM
+     order: ±1 is left/right, ±$cols is the row directly above/below, and
+     ±($cols ∓ 1) are the diagonals. Each call carries the edge guard for the
+     boundary it would otherwise wrap across — so a glyph at a row's edge never
+     magnifies the far side of an adjacent row. */
+  @mixin dock-falloff($cols) {
+    $near: 1.34;
+    $diag: 1.16;
+
+    @include dock-cell(1, 'after', 'right', $near, $cols); // right
+    @include dock-cell(1, 'before', 'left', $near, $cols); // left
+    @include dock-cell($cols, 'after', '', $near, $cols); // down
+    @include dock-cell($cols, 'before', '', $near, $cols); // up
+
+    @include dock-cell($cols + 1, 'after', 'right', $diag, $cols); // down-right
+    @include dock-cell($cols - 1, 'after', 'left', $diag, $cols); // down-left
+    @include dock-cell($cols - 1, 'before', 'right', $diag, $cols); // up-right
+    @include dock-cell($cols + 1, 'before', 'left', $diag, $cols); // up-left
+  }
+
+  /* Mac-Dock magnification: the hovered glyph swells to the accent colour and
+     the surrounding glyphs scale down with distance, so the band bows toward
+     the cursor in 2D. Pure CSS — the `scale` property is composited, so it only
+     costs on hover, never on scroll. Where :has() is unsupported the hovered
+     glyph still scales (graceful fallback); movement is gated to motion-allowed.
+     The cell count differs per breakpoint, so the falloff is too. */
+  @include can-hover {
+    .hero-icon:hover {
+      color: var(--color-primary);
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      /* Raise the hovered cell so its overspilling glyph paints over the
+         neighbours — but never scale the CELL itself (a scaled cell would
+         overlap the next one and keep stealing the hover). Only the glyph grows. */
+      .hero-icon:hover {
+        z-index: 1;
+      }
+
+      .hero-icon:hover .hero-icon-svg {
+        scale: 1.5;
+      }
+
+      @media (width < 48em) {
+        @include dock-falloff(4);
+      }
+
+      @include from('md') {
+        @include dock-falloff(6);
+      }
     }
   }
 
@@ -922,6 +1045,14 @@ const toc = [
     inline-size: clamp(2.75rem, 7vw, 5rem);
     block-size: clamp(2.75rem, 7vw, 5rem);
     fill: currentcolor;
+    /* The glyph alone magnifies; the cell stays a fixed, seamless hover target.
+       pointer-events:none means the overspilling glyph never intercepts the
+       cursor, so moving toward a neighbour hands hover cleanly to that cell. */
+    pointer-events: none;
+
+    @include can-hover {
+      transition: scale var(--duration-normal) var(--easing-standard);
+    }
 
     @include forced-colors {
       fill: CanvasText;

--- a/src/components/PillarHeader/PillarHeader.vue
+++ b/src/components/PillarHeader/PillarHeader.vue
@@ -3,6 +3,14 @@
        the pillar title (the real <h2> for this region), and an optional lead.
        The icon is decorative; the heading carries the accessible name. -->
   <header class="pillar-header">
+    <!-- Oversized echo of this pillar's mark, bleeding off the right edge as a
+         faint watermark. Purely decorative; static (no animation), so it costs
+         nothing at runtime. -->
+    <span
+      class="pillar-header-watermark"
+      aria-hidden="true"
+      v-html="icons[icon]"
+    ></span>
     <p class="pillar-header-eyebrow">{{ eyebrow }}</p>
     <div class="pillar-header-top">
       <span class="pillar-header-icon" aria-hidden="true" v-html="icons[icon]"></span>
@@ -91,6 +99,72 @@ const icons: Record<string, string> = {
   .pillar-header-icon :deep(svg) {
     inline-size: 2rem;
     block-size: 2rem;
+  }
+
+  /* The giant watermark: positioned against the .pillar (App.vue gives it
+     position: relative + isolation), bleeding off the right edge where
+     overflow-x: clip on the app shell hides the overspill — no scrollbar. Sits
+     at z-index -1, behind the chapter's content. Faint, so it never competes
+     with text; opaque demo cards paint over it entirely. */
+  .pillar-header-watermark {
+    position: absolute;
+    z-index: -1;
+    inset-block-start: -2rem;
+    inset-inline-end: 0;
+    /* Mobile-first: smaller and pushed further off the edge. The narrow layout
+       has no side gutter, so a big mark would sit right under the text — this
+       keeps it a corner sliver and protects the contrast ratio. */
+    inline-size: 16rem;
+    block-size: 16rem;
+    color: var(--color-primary);
+    opacity: 0.09;
+    transform: translateX(52%) rotate(-12deg);
+    pointer-events: none;
+
+    /* Desktop: much larger, and bled further past the edge (the app shell's
+       overflow-x: clip hides the overspill, so there's still no scrollbar). */
+    @include from('md') {
+      inline-size: 36rem;
+      block-size: 36rem;
+      transform: translateX(46%) rotate(-12deg);
+    }
+
+    /* Parallax: the mark drifts slower than the content for a sense of depth.
+       It animates the `translate` property only (composited, off the main
+       thread via the element's own view-timeline), so it adds no paint cost
+       while scrolling — unlike colour/gradient animation. Support + motion
+       gated; without either, the mark is simply static. */
+    @media (prefers-reduced-motion: no-preference) {
+      @supports (animation-timeline: view()) {
+        animation: pillar-watermark-parallax linear both;
+        animation-timeline: view();
+        animation-range: cover;
+      }
+    }
+
+    /* Decorative flourish — drop it where the OS flattens the palette. */
+    @include forced-colors {
+      display: none;
+    }
+  }
+
+  .pillar-header-watermark :deep(svg) {
+    inline-size: 100%;
+    block-size: 100%;
+    /* Thinner stroke reads better blown up to poster scale. */
+    stroke-width: 1;
+  }
+
+  /* Lag the mark behind the scroll — the `translate` runs opposite the travel,
+     so the watermark appears to move slower than the foreground. */
+  @keyframes pillar-watermark-parallax {
+    from {
+      translate: 0 -30%;
+    }
+
+    to {
+      translate: 0 30%;
+    }
   }
 
   .pillar-header-eyebrow {


### PR DESCRIPTION
### Summary
Add visual motion and interaction polish to the app's hero and pillar header UI.

### What changed
- Enhanced App.vue with:
  - animated hero icon entrance sequence
  - hover interaction that magnifies nearby icons in a Mac-Dock-style effect
  - layout and styling polish for the hero icon grid and section headings
- Updated PillarHeader.vue with:
  - decorative oversized watermark markup
  - visual refinement for pillar header presentation

### Why
- Adds engaging motion and responsive visual feedback
- Improves the interface’s sense of interaction without changing core accessibility semantics
- Makes the hero and section headings feel more polished and dynamic