### PR TITLE
style: add hero watermarks and pillar icons for enhanced visual continuity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,21 @@
 
   <div class="app-shell">
     <header class="hero">
+      <!-- Oversized, faint echoes of the pillar marks, bleeding off the hero's
+           outer edges — the same watermark motif that opens each pillar below,
+           so the cover and the chapters read as one continuous set. Purely
+           decorative (aria-hidden), behind the content at z-index -1. -->
+      <span
+        class="hero-watermark hero-watermark-lead"
+        aria-hidden="true"
+        v-html="pillarIcons.craft"
+      ></span>
+      <span
+        class="hero-watermark hero-watermark-trail"
+        aria-hidden="true"
+        v-html="pillarIcons.next"
+      ></span>
+
       <div class="hero-top">
         <p class="hero-brand">
           <img class="hero-brand-mark" src="/favicon.svg" alt="" />
@@ -420,6 +435,7 @@ import LightDarkDemo from './craft/demos/LightDarkDemo.vue'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'
 import { heroIcons } from './icons/heroIcons'
+import { pillarIcons } from './icons/pillarIcons'
 
 const dialog = ref<InstanceType<typeof AppDialog> | null>(null)
 const name = ref('')
@@ -519,6 +535,11 @@ const toc = [
     max-inline-size: 80rem;
     margin-inline: auto;
     padding: var(--space-6) var(--space-4) var(--space-8);
+    /* Anchor + own stacking context for the hero watermarks (faint oversized
+       marks painted at z-index -1, the same treatment PillarHeader uses).
+       `isolate` keeps that negative layer trapped above the page glow. */
+    position: relative;
+    isolation: isolate;
   }
 
   .hero-top {
@@ -900,6 +921,80 @@ const toc = [
     color: var(--color-text-subtle);
   }
 
+  /* The hero's edge watermarks: oversized, faint echoes of the pillar marks
+     that frame the cover the way each pillar's mark opens its chapter — so the
+     hero reads as the first of the set, not a separate thing. Positioned
+     against the hero (which supplies position + isolation) and bled off its
+     outer edges, where the app shell's overflow-x: clip hides the overspill —
+     no horizontal scrollbar. z-index -1 keeps them behind the title; faint
+     enough that they never touch the contrast of the text in front. */
+  .hero-watermark {
+    position: absolute;
+    z-index: -1;
+    inline-size: 14rem;
+    block-size: 14rem;
+    color: var(--color-primary);
+    opacity: 0.08;
+    pointer-events: none;
+
+    @include from('md') {
+      inline-size: 30rem;
+      block-size: 30rem;
+    }
+
+    /* Parallax: each mark drifts slower than the content as the hero scrolls
+       away, for a sense of depth. Animates the `translate` property only
+       (composited, off the main thread via the element's own view-timeline),
+       so it adds no paint cost while scrolling — unlike colour animation.
+       Support + motion gated; without either, the mark is simply static. */
+    @media (prefers-reduced-motion: no-preference) {
+      @supports (animation-timeline: view()) {
+        animation: hero-watermark-parallax linear both;
+        animation-timeline: view();
+        animation-range: cover;
+      }
+    }
+
+    /* Decorative flourish — drop it where the OS flattens the palette. */
+    @include forced-colors {
+      display: none;
+    }
+  }
+
+  .hero-watermark :deep(svg) {
+    inline-size: 100%;
+    block-size: 100%;
+    /* Thinner stroke reads better blown up to poster scale. */
+    stroke-width: 1;
+  }
+
+  /* Upper-left, bleeding off the left edge. */
+  .hero-watermark-lead {
+    inset-block-start: 12%;
+    inset-inline-start: 0;
+    transform: translateX(-46%) rotate(-12deg);
+  }
+
+  /* Lower-right, bleeding off the right edge — handing off into the first
+     pillar's own right-edge watermark just below the fold. */
+  .hero-watermark-trail {
+    inset-block-end: 9%;
+    inset-inline-end: 0;
+    transform: translateX(46%) rotate(10deg);
+  }
+
+  /* Lag the marks behind the scroll — the `translate` runs opposite the travel,
+     so each watermark appears to drift slower than the foreground. */
+  @keyframes hero-watermark-parallax {
+    from {
+      translate: 0 -22%;
+    }
+
+    to {
+      translate: 0 22%;
+    }
+  }
+
   /* The decorative wayfinding band — large, boxless pictograms that read as a
      poster. The page's own topics carry the brand accent; the signage glyphs
      stay in the bold ink colour, so the "mix" still reads. */
@@ -940,7 +1035,7 @@ const toc = [
        glyph (.hero-icon-svg) so the cell stays a fixed-size hover target.
        Cosmetic only — the whole band is aria-hidden. */
     @include can-hover {
-      transition: color var(--duration-fast) var(--easing-standard);
+      transition: color var(--duration-normal) var(--easing-standard);
     }
   }
 
@@ -1028,7 +1123,7 @@ const toc = [
       }
 
       .hero-icon:hover .hero-icon-svg {
-        scale: 1.5;
+        scale: 1.65;
       }
 
       @media (width < 48em) {
@@ -1051,7 +1146,7 @@ const toc = [
     pointer-events: none;
 
     @include can-hover {
-      transition: scale var(--duration-normal) var(--easing-standard);
+      transition: scale var(--duration-slow) var(--easing-standard);
     }
 
     @include forced-colors {

--- a/src/components/PillarHeader/PillarHeader.vue
+++ b/src/components/PillarHeader/PillarHeader.vue
@@ -21,37 +21,14 @@
 </template>
 
 <script setup lang="ts">
+import { pillarIcons as icons, type PillarIconName } from '../../icons/pillarIcons'
+
 defineProps<{
-  icon: 'standard' | 'craft' | 'next' | 'proof'
+  icon: PillarIconName
   eyebrow: string
   title: string
   titleId: string
 }>()
-
-// Decorative line icons, one per pillar — stroke-based so they echo the
-// brand's focus-ring motif, on a shared 24×24 geometry so the set reads as
-// one family. Kept inline (not a sprite) since there are only four.
-const svg = (paths: string) =>
-  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`
-
-const icons: Record<string, string> = {
-  // Checklist — the requirement / the standard.
-  standard: svg(
-    '<rect x="4" y="3" width="16" height="18" rx="2.5"/><path d="m7.2 8.2 1.3 1.3 2.3-2.5"/><path d="M13.5 8h3.3"/><path d="m7.2 14.2 1.3 1.3 2.3-2.5"/><path d="M13.5 14h3.3"/>',
-  ),
-  // Curly braces — the craft of modern CSS / HTML.
-  craft: svg(
-    '<path d="M9.5 4c-1.8 0-2.5.8-2.5 2.6v2c0 1.3-.5 1.9-1.8 1.9 1.3 0 1.8.6 1.8 1.9v2c0 1.8.7 2.6 2.5 2.6"/><path d="M14.5 4c1.8 0 2.5.8 2.5 2.6v2c0 1.3.5 1.9 1.8 1.9-1.3 0-1.8.6-1.8 1.9v2c0 1.8-.7 2.6-2.5 2.6"/>',
-  ),
-  // Sparkle — what's arriving next.
-  next: svg(
-    '<path d="M12 3.5c.7 4 1.8 5.1 5.5 5.8-3.7.7-4.8 1.8-5.5 5.8-.7-4-1.8-5.1-5.5-5.8 3.7-.7 4.8-1.8 5.5-5.8z"/><path d="M18 14.5c.3 1.6.8 2.1 2.3 2.4-1.5.3-2 .8-2.3 2.4-.3-1.6-.8-2.1-2.3-2.4 1.5-.3 2-.8 2.3-2.4z"/>',
-  ),
-  // Shield + check — the proof it holds up.
-  proof: svg(
-    '<path d="M12 3 5 5.8v5.2c0 4.3 3 7.4 7 8.9 4-1.5 7-4.6 7-8.9V5.8L12 3z"/><path d="m8.8 11.8 2.2 2.2 4.2-4.4"/>',
-  ),
-}
 </script>
 
 <style scoped lang="scss">

--- a/src/icons/pillarIcons.ts
+++ b/src/icons/pillarIcons.ts
@@ -1,0 +1,32 @@
+/**
+ * Pillar marks — the four decorative line icons, one per pillar.
+ *
+ * Stroke-based so they echo the brand's focus-ring motif, on a shared 24×24
+ * geometry so the set reads as one family. Used twice: as each pillar's small
+ * header tile, and — blown up, faint, and rotated — as the oversized
+ * watermarks behind the hero and each pillar. Decorative only (always
+ * rendered aria-hidden); the headings carry the accessible names.
+ */
+const svg = (paths: string) =>
+  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`
+
+export type PillarIconName = 'standard' | 'craft' | 'next' | 'proof'
+
+export const pillarIcons: Record<PillarIconName, string> = {
+  // Checklist — the requirement / the standard.
+  standard: svg(
+    '<rect x="4" y="3" width="16" height="18" rx="2.5"/><path d="m7.2 8.2 1.3 1.3 2.3-2.5"/><path d="M13.5 8h3.3"/><path d="m7.2 14.2 1.3 1.3 2.3-2.5"/><path d="M13.5 14h3.3"/>',
+  ),
+  // Curly braces — the craft of modern CSS / HTML.
+  craft: svg(
+    '<path d="M9.5 4c-1.8 0-2.5.8-2.5 2.6v2c0 1.3-.5 1.9-1.8 1.9 1.3 0 1.8.6 1.8 1.9v2c0 1.8.7 2.6 2.5 2.6"/><path d="M14.5 4c1.8 0 2.5.8 2.5 2.6v2c0 1.3.5 1.9 1.8 1.9-1.3 0-1.8.6-1.8 1.9v2c0 1.8-.7 2.6-2.5 2.6"/>',
+  ),
+  // Sparkle — what's arriving next.
+  next: svg(
+    '<path d="M12 3.5c.7 4 1.8 5.1 5.5 5.8-3.7.7-4.8 1.8-5.5 5.8-.7-4-1.8-5.1-5.5-5.8 3.7-.7 4.8-1.8 5.5-5.8z"/><path d="M18 14.5c.3 1.6.8 2.1 2.3 2.4-1.5.3-2 .8-2.3 2.4-.3-1.6-.8-2.1-2.3-2.4 1.5-.3 2-.8 2.3-2.4z"/>',
+  ),
+  // Shield + check — the proof it holds up.
+  proof: svg(
+    '<path d="M12 3 5 5.8v5.2c0 4.3 3 7.4 7 8.9 4-1.5 7-4.6 7-8.9V5.8L12 3z"/><path d="m8.8 11.8 2.2 2.2 4.2-4.4"/>',
+  ),
+}


### PR DESCRIPTION
style: frame the hero with edge watermarks
Carries the pillar watermark motif up into the hero. On load the first pillar's mark already peeks in from below; this adds two more faint marks bleeding off the hero's own edges so that read is clearly intentional — the cover now opens the same way each chapter does.

Changes

Two hero watermarks — the craft (braces) mark off the upper-left and the next (sparkle) off the lower-right, framing the title diagonally and continuing into the first pillar's right-edge mark below the fold.
Shared the marks — extracted the four pillar line-icons from PillarHeader into src/icons/pillarIcons.ts; the hero and the pillar headers now draw from one source instead of duplicating SVG strings.
Behaviour — identical to the existing pillar watermarks: faint (8% opacity), behind content at z-index: -1, parallax driven by the element's own view-timeline (animates translate only, so it's composited and costs nothing during scroll), gated behind prefers-reduced-motion + @supports (animation-timeline: view()), and dropped entirely under forced-colors. Horizontal bleed is clipped by the shell's overflow-x: clip — no scrollbar.

Testing — vite build passes; stylelint + vue-tsc clean. Verified in-browser across light/dark and desktop/mobile: marks frame the hero, no horizontal scroll, and the whole band stays aria-hidden so nothing reaches the accessibility tree.