### PR TITLE
chore: trim comments project-wide — let the code speak for itself

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,10 +5,6 @@
 
   <div class="app-shell">
     <header class="hero">
-      <!-- Oversized, faint echoes of the pillar marks, bleeding off the hero's
-           outer edges — the same watermark motif that opens each pillar below,
-           so the cover and the chapters read as one continuous set. Purely
-           decorative (aria-hidden), behind the content at z-index -1. -->
       <span
         class="hero-watermark hero-watermark-lead"
         aria-hidden="true"
@@ -45,9 +41,6 @@
       </div>
 
       <div class="hero-body">
-        <!-- A bold band of signage pictograms + this site's own accessibility
-             concepts — the "find your way" metaphor, full size. Purely
-             decorative, so the whole grid is aria-hidden. -->
         <div class="hero-icons" aria-hidden="true">
           <span
             v-for="(icon, i) in heroIcons"
@@ -82,10 +75,6 @@
     </header>
 
     <div class="app-body">
-      <!-- Wayfinding nav. On desktop it's a sticky sidebar: the four pillars,
-           each expanded to its sections. Below `lg` it becomes a sticky top bar
-           of just the four pillar tabs, so it never buries the content. Active
-           state is driven purely by scroll position (view-timeline), no JS. -->
       <nav class="toc" aria-label="Sections">
         <p class="toc-heading">On this page</p>
         <ol class="toc-groups" role="list">
@@ -110,9 +99,6 @@
       </nav>
 
       <main id="main" tabindex="-1" class="site-main">
-      <!-- ===================================================================
-           Pillar 1 — The requirement: accessibility as a living standard
-      ==================================================================== -->
       <section id="standard" class="pillar scrollspy-region" aria-labelledby="standard-title">
         <PillarHeader
           icon="standard"
@@ -164,9 +150,6 @@
         </section>
       </section>
 
-      <!-- ===================================================================
-           Pillar 2 — The platform's answer (a) shipping today: the craft
-      ==================================================================== -->
       <section id="craft" class="pillar scrollspy-region" aria-labelledby="craft-title">
         <PillarHeader
           icon="craft"
@@ -275,9 +258,6 @@
         </section>
       </section>
 
-      <!-- ===================================================================
-           Pillar 3 — The platform's answer (b) arriving next: the showcase
-      ==================================================================== -->
       <section id="showcase" class="pillar scrollspy-region" aria-labelledby="showcase-title">
         <PillarHeader
           icon="next"
@@ -316,9 +296,6 @@
         </div>
       </section>
 
-      <!-- ===================================================================
-           Pillar 4 — The proof: how you know any of it actually works
-      ==================================================================== -->
       <section id="testing" class="pillar scrollspy-region" aria-labelledby="testing-title">
         <PillarHeader
           icon="proof"
@@ -377,8 +354,6 @@
         broken page. New features extend the baseline here — they never replace it.
       </p>
 
-      <!-- The statement demonstrates the thesis while making it: progressive
-           disclosure with a native <details>, no JavaScript. -->
       <details class="footer-details">
         <summary class="footer-summary">What that means in practice</summary>
         <div class="footer-details-body">
@@ -454,8 +429,7 @@ const groups = computed(() => [
   },
 ])
 
-// The table of contents: the four pillars, each with its real <h2> sections.
-// Drives the sidebar nav; ids match the headings in the template above.
+// ids must match the in-template section ids — anchor + scroll-spy targets.
 const toc = [
   {
     id: 'standard',
@@ -498,20 +472,15 @@ const toc = [
 </script>
 
 <style scoped lang="scss">
-/* Page-level composition belongs in the layout layer. */
 @layer layout {
   .app-shell {
     position: relative;
     min-block-size: 100dvh;
-    /* Cards in the timeline slide in from off the right edge; clip at the page
-       root so they enter from off-screen without spawning a horizontal
-       scrollbar. `clip` (not `hidden`) keeps the sticky sidebar working — it
-       doesn't establish a scroll container. */
+    /* `clip` (not `hidden`) hides the timeline cards' off-screen entry without
+       a scrollbar, and doesn't establish a scroll container (sticky sidebar). */
     overflow-x: clip;
   }
 
-  /* A soft accent glow behind everything — the modern "canvas" feel.
-     Decorative and translucent, so it's dropped under reduced transparency. */
   .app-shell::before {
     content: '';
     position: fixed;
@@ -525,8 +494,6 @@ const toc = [
     }
   }
 
-  /* A full-screen, poster-style opener: the top bar, then the icon band + title
-     centred in the remaining height, then a scroll cue at the foot. */
   .hero {
     display: grid;
     grid-template-rows: auto 1fr auto;
@@ -535,9 +502,7 @@ const toc = [
     max-inline-size: 80rem;
     margin-inline: auto;
     padding: var(--space-6) var(--space-4) var(--space-8);
-    /* Anchor + own stacking context for the hero watermarks (faint oversized
-       marks painted at z-index -1, the same treatment PillarHeader uses).
-       `isolate` keeps that negative layer trapped above the page glow. */
+    /* Own stacking context so the z-index:-1 watermarks sit above the page glow. */
     position: relative;
     isolation: isolate;
   }
@@ -590,9 +555,6 @@ const toc = [
     }
   }
 
-  /* The hero spans full width; below it a two-column body pairs the sticky
-     wayfinding sidebar with the content column. Block flow on mobile (so the
-     sticky tab bar can travel); two-column grid from `lg`. */
   .app-body {
     max-inline-size: 72rem;
     margin-inline: auto;
@@ -612,22 +574,17 @@ const toc = [
     min-inline-size: 0; /* let the content column shrink, not overflow */
     padding-block-end: var(--space-16);
 
-    /* Pull the pillars far apart on wider screens so each reads as its own
-       beat rather than one continuous scroll. */
     @include from('md') {
       gap: var(--space-40);
     }
   }
 
-  /* A pillar groups several sections under one narrative beat. */
   .pillar {
     display: grid;
     gap: var(--space-12);
-    /* Keep the heading clear of the sticky spine after a fragment jump. */
+    /* Clear the sticky nav after a fragment jump. */
     scroll-margin-block-start: var(--space-16);
-    /* Anchor + own stacking context for the giant pillar watermark
-       (PillarHeader paints a faint oversized mark at z-index -1). `isolate`
-       keeps that negative layer trapped here, above the page background. */
+    /* Own stacking context so the PillarHeader's z-index:-1 watermark sits above the page background. */
     position: relative;
     isolation: isolate;
   }
@@ -653,7 +610,6 @@ const toc = [
     gap: var(--space-6);
   }
 
-  /* A closing coda, set off from the argument above by a hairline rule. */
   .site-footer {
     display: grid;
     gap: var(--space-4);
@@ -665,16 +621,11 @@ const toc = [
 }
 
 @layer components {
-  /* --- Wayfinding nav ------------------------------------------------------
-     Below `lg`: a sticky glassy top bar of the four pillar tabs (sections
-     hidden) — compact, so it never buries the content. From `lg`: a sticky left
-     sidebar with every section listed. */
   .toc {
     position: sticky;
     inset-block-start: 0;
     z-index: 5;
     margin-block-end: var(--space-6);
-    /* Bleed past the body's inline padding so the bar spans edge to edge. */
     margin-inline: calc(var(--space-4) * -1);
     padding: var(--space-2) var(--space-4);
     border-block-end: 1px solid var(--color-border);
@@ -682,7 +633,6 @@ const toc = [
     backdrop-filter: blur(12px);
 
     @include from('lg') {
-      /* Desktop: a sticky rail; drop the bar chrome. */
       inset-block-start: var(--space-6);
       align-self: start;
       max-block-size: calc(100dvh - var(--space-12));
@@ -705,7 +655,6 @@ const toc = [
     }
   }
 
-  /* "On this page": a quiet heading on the desktop rail; hidden in the bar. */
   .toc-heading {
     display: none;
 
@@ -721,7 +670,6 @@ const toc = [
   }
 
   .toc-groups {
-    /* Mobile: pillar tabs that wrap onto multiple rows (no horizontal scroll). */
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
@@ -767,7 +715,6 @@ const toc = [
     }
   }
 
-  /* The pillar number is a desktop-rail flourish; the mobile tabs stay compact. */
   .toc-group-n {
     display: none;
 
@@ -779,7 +726,6 @@ const toc = [
     }
   }
 
-  /* Sub-sections only appear in the desktop sidebar. */
   .toc-sections {
     display: none;
 
@@ -813,11 +759,9 @@ const toc = [
     }
   }
 
-  /* Pure-CSS scroll spy. Each pillar and each section owns a named
-     view-timeline, hoisted to a common ancestor; the matching nav link reads it
-     (timeline assigned inline from the toc data) and brightens while its target
-     holds the viewport. Scroll-linked, so no reduced-motion override is needed —
-     gated only on support, with the plain links as the fallback. */
+  /* Pure-CSS scroll spy: each pillar owns a named view-timeline; the matching
+     nav link reads it (set inline from the toc data) and brightens while its
+     pillar holds the viewport. Scroll-linked, so support-gated only. */
   @supports (animation-timeline: view()) {
     .app-shell {
       timeline-scope: --vt-standard, --vt-craft, --vt-showcase, --vt-testing;
@@ -828,17 +772,14 @@ const toc = [
     #showcase { view-timeline-name: --vt-showcase; }
     #testing { view-timeline-name: --vt-testing; }
 
-    /* The group link tracks its pillar (timeline set inline from the toc data).
-       Section-level single-active isn't reliably expressible in pure CSS — short
-       adjacent sections all satisfy a "cover" range at once — so we highlight the
-       current pillar and leave sections to hover / focus. */
+    /* Pillar-level only: short adjacent sections all satisfy a "cover" range at
+       once, so per-section single-active isn't reliable in pure CSS. */
     .toc-group-link {
       animation: toc-group-active linear both;
       animation-range: cover 0% cover 100%;
     }
 
-    /* A plateau, not a peak: full strength across 12%–88% of the cover range so
-       the active pillar stays lit even at the top of a tall region. */
+    /* Plateau across 12%–88% so the active pillar stays lit even on tall regions. */
     @keyframes toc-group-active {
       0%,
       100% {
@@ -853,8 +794,7 @@ const toc = [
       }
     }
 
-    /* Forced colors flattens the background tint; mark the active tab with a
-       border instead so it stays distinguishable. */
+    /* Forced colors flattens the tint — mark the active tab with a border instead. */
     @include forced-colors {
       @keyframes toc-group-active {
         0%,
@@ -870,9 +810,6 @@ const toc = [
     }
   }
 
-  /* The brand lockup: mark + wordmark, flex-aligned so the mark centres on the
-     text (same treatment as the legal pages). The poster <h1> is a separate
-     hook, so it doesn't repeat the name. */
   .hero-brand {
     display: inline-flex;
     align-items: center;
@@ -893,12 +830,11 @@ const toc = [
 
   .hero-title {
     inline-size: fit-content;
-    /* Poster-scale: fluid from a strong mobile size up to a huge desktop one. */
     font-size: clamp(3rem, 12vw, 9rem);
     font-weight: 800;
     line-height: 1;
     letter-spacing: var(--tracking-tight);
-    /* Gradient text. Safari still needs the prefixed background-clip. */
+    /* Safari still needs the prefixed background-clip for gradient text. */
     background: var(--gradient-accent);
     /* stylelint-disable-next-line property-no-vendor-prefix -- Safari */
     -webkit-background-clip: text;
@@ -921,13 +857,6 @@ const toc = [
     color: var(--color-text-subtle);
   }
 
-  /* The hero's edge watermarks: oversized, faint echoes of the pillar marks
-     that frame the cover the way each pillar's mark opens its chapter — so the
-     hero reads as the first of the set, not a separate thing. Positioned
-     against the hero (which supplies position + isolation) and bled off its
-     outer edges, where the app shell's overflow-x: clip hides the overspill —
-     no horizontal scrollbar. z-index -1 keeps them behind the title; faint
-     enough that they never touch the contrast of the text in front. */
   .hero-watermark {
     position: absolute;
     z-index: -1;
@@ -942,11 +871,8 @@ const toc = [
       block-size: 30rem;
     }
 
-    /* Parallax: each mark drifts slower than the content as the hero scrolls
-       away, for a sense of depth. Animates the `translate` property only
-       (composited, off the main thread via the element's own view-timeline),
-       so it adds no paint cost while scrolling — unlike colour animation.
-       Support + motion gated; without either, the mark is simply static. */
+    /* Animates `translate` only, so the parallax stays composited — no paint
+       cost on scroll. Static where motion or view-timelines aren't available. */
     @media (prefers-reduced-motion: no-preference) {
       @supports (animation-timeline: view()) {
         animation: hero-watermark-parallax linear both;
@@ -955,7 +881,6 @@ const toc = [
       }
     }
 
-    /* Decorative flourish — drop it where the OS flattens the palette. */
     @include forced-colors {
       display: none;
     }
@@ -964,27 +889,21 @@ const toc = [
   .hero-watermark :deep(svg) {
     inline-size: 100%;
     block-size: 100%;
-    /* Thinner stroke reads better blown up to poster scale. */
     stroke-width: 1;
   }
 
-  /* Upper-left, bleeding off the left edge. */
   .hero-watermark-lead {
     inset-block-start: 12%;
     inset-inline-start: 0;
     transform: translateX(-46%) rotate(-12deg);
   }
 
-  /* Lower-right, bleeding off the right edge — handing off into the first
-     pillar's own right-edge watermark just below the fold. */
   .hero-watermark-trail {
     inset-block-end: 9%;
     inset-inline-end: 0;
     transform: translateX(46%) rotate(10deg);
   }
 
-  /* Lag the marks behind the scroll — the `translate` runs opposite the travel,
-     so each watermark appears to drift slower than the foreground. */
   @keyframes hero-watermark-parallax {
     from {
       translate: 0 -22%;
@@ -995,15 +914,11 @@ const toc = [
     }
   }
 
-  /* The decorative wayfinding band — large, boxless pictograms that read as a
-     poster. The page's own topics carry the brand accent; the signage glyphs
-     stay in the bold ink colour, so the "mix" still reads. */
   .hero-icons {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    /* No grid gap: the cells tile edge-to-edge so the Dock hover target is
-       continuous — moving across the band never drops into a dead gap between
-       glyphs. The visual spacing comes from padding inside each cell instead. */
+    /* No gap: cells tile edge-to-edge so the Dock hover target is continuous
+       (spacing comes from padding inside each cell). */
 
     @include from('md') {
       grid-template-columns: repeat(6, 1fr);
@@ -1013,8 +928,6 @@ const toc = [
   .hero-icon {
     display: grid;
     place-items: center;
-    /* Padding (not gap) spaces the glyphs, so each cell is a seamless hit area
-       that fills its track. */
     padding: var(--space-3);
     color: var(--color-text);
 
@@ -1022,18 +935,14 @@ const toc = [
       color: var(--color-primary);
     }
 
-    /* One-time staggered entrance — the band assembles itself on load. The
-       whole thing lives inside no-preference so reduced-motion users never see
-       the opacity:0 start (no flash), just the icons already in place. The
-       per-icon delay comes from the inline --i (its index). */
+    /* Staggered entrance (delay from the inline --i). Inside no-preference so
+       reduced-motion users never see the opacity:0 start. */
     @media (prefers-reduced-motion: no-preference) {
       animation: hero-icon-in 0.5s var(--easing-enter) both;
       animation-delay: calc(var(--i, 0) * 45ms);
     }
 
-    /* Only the colour transitions on the cell; the magnification lives on the
-       glyph (.hero-icon-svg) so the cell stays a fixed-size hover target.
-       Cosmetic only — the whole band is aria-hidden. */
+    /* Cell transitions colour only; magnification is on the glyph (below). */
     @include can-hover {
       transition: color var(--duration-normal) var(--easing-standard);
     }
@@ -1046,13 +955,10 @@ const toc = [
     }
   }
 
-  /* One magnified glyph: the cell $offset siblings away in DOM order, walked
-     either forward ($dir: 'after', via `+`) or backward ('before', via :has()).
-     $edge suppresses the row-boundary wrap — '' for vertical neighbours (a
-     column never wraps), 'right' to skip when the hovered glyph is last in its
-     row, 'left' when it's first. So an edge glyph only reaches the siblings it
-     visually touches, not the ones that are merely adjacent in source order.
-     The scale lands on the glyph (.hero-icon-svg), never the cell. */
+  /* Magnifies the glyph $offset siblings away — forward ($dir 'after', via `+`)
+     or backward ('before', via :has()). $edge guards the row-boundary wrap:
+     'right'/'left' skip when the hovered glyph is last/first in its row, ''
+     for vertical neighbours (a column never wraps). Scale lands on the glyph. */
   @mixin dock-cell($offset, $dir, $edge, $scale, $cols) {
     $guard: '';
     @if $edge == 'right' {
@@ -1083,11 +989,9 @@ const toc = [
     }
   }
 
-  /* The 2D bulge for a grid of $cols columns. Grid geometry maps onto DOM
-     order: ±1 is left/right, ±$cols is the row directly above/below, and
-     ±($cols ∓ 1) are the diagonals. Each call carries the edge guard for the
-     boundary it would otherwise wrap across — so a glyph at a row's edge never
-     magnifies the far side of an adjacent row. */
+  /* 2D bulge for $cols columns: in DOM order ±1 is left/right, ±$cols is the
+     row above/below, ±($cols ∓ 1) the diagonals. Each call guards the row edge
+     it would otherwise wrap across. */
   @mixin dock-falloff($cols) {
     $near: 1.34;
     $diag: 1.16;
@@ -1103,21 +1007,18 @@ const toc = [
     @include dock-cell($cols + 1, 'before', 'left', $diag, $cols); // up-left
   }
 
-  /* Mac-Dock magnification: the hovered glyph swells to the accent colour and
-     the surrounding glyphs scale down with distance, so the band bows toward
-     the cursor in 2D. Pure CSS — the `scale` property is composited, so it only
-     costs on hover, never on scroll. Where :has() is unsupported the hovered
-     glyph still scales (graceful fallback); movement is gated to motion-allowed.
-     The cell count differs per breakpoint, so the falloff is too. */
+  /* Mac-Dock magnification, pure CSS: the hovered glyph swells and neighbours
+     fall off with distance. `scale` is composited, so it costs only on hover,
+     never on scroll. Without :has() the hovered glyph still scales (fallback).
+     Falloff is per-breakpoint since the column count differs. */
   @include can-hover {
     .hero-icon:hover {
       color: var(--color-primary);
     }
 
     @media (prefers-reduced-motion: no-preference) {
-      /* Raise the hovered cell so its overspilling glyph paints over the
-         neighbours — but never scale the CELL itself (a scaled cell would
-         overlap the next one and keep stealing the hover). Only the glyph grows. */
+      /* Raise the hovered cell so its glyph paints over neighbours. Never scale
+         the CELL — a scaled cell would overlap the next and trap the hover. */
       .hero-icon:hover {
         z-index: 1;
       }
@@ -1140,9 +1041,8 @@ const toc = [
     inline-size: clamp(2.75rem, 7vw, 5rem);
     block-size: clamp(2.75rem, 7vw, 5rem);
     fill: currentcolor;
-    /* The glyph alone magnifies; the cell stays a fixed, seamless hover target.
-       pointer-events:none means the overspilling glyph never intercepts the
-       cursor, so moving toward a neighbour hands hover cleanly to that cell. */
+    /* pointer-events:none so the overspilling glyph never intercepts the cursor
+       — hover hands off cleanly to the neighbouring cell. */
     pointer-events: none;
 
     @include can-hover {
@@ -1154,7 +1054,6 @@ const toc = [
     }
   }
 
-  /* Scroll affordance at the foot of the full-screen hero. */
   .hero-scroll {
     display: inline-flex;
     align-items: center;
@@ -1183,7 +1082,6 @@ const toc = [
     inline-size: 1.25rem;
     block-size: 1.25rem;
     fill: currentcolor;
-    /* A hardcoded duration (not a motion token), so silence it explicitly. */
     animation: hero-bob 1.8s ease-in-out infinite;
 
     @include reduced-motion {
@@ -1202,8 +1100,6 @@ const toc = [
     }
   }
 
-  /* Section headings get the fluid display scale; intro paragraphs stay
-     readable at prose width even though the cards below run wider. */
   .demo > h2 {
     font-size: var(--text-display-sm);
     font-weight: 800;
@@ -1216,19 +1112,15 @@ const toc = [
     color: var(--color-text-subtle);
   }
 
-  /* Sections ease in as they scroll into view — a scroll-driven animation,
-     so it runs off the main thread with no scroll listeners. Added ONLY for
-     users who haven't asked to reduce motion (progressive enhancement: no
-     motion is the default), and only where view() timelines are supported. */
+  /* Sections ease in on scroll — view-timeline driven, so off the main thread
+     with no scroll listeners. Motion- and support-gated. */
   @media (prefers-reduced-motion: no-preference) {
     @supports (animation-timeline: view()) {
       .demo {
         animation: section-reveal linear both;
         animation-timeline: view();
-        /* A fixed-length reveal (px, not %) so tall sections — the timeline,
-           the showcase grid — don't stretch the motion over their whole
-           height. Runs over the first ~420px after the section starts to
-           enter, the same distance for every section regardless of height. */
+        /* Fixed px length (not %) so tall sections don't stretch the reveal
+           over their whole height — same ~420px distance for every section. */
         animation-range: entry 0% entry 420px;
       }
 

--- a/src/components/AppButton/AppButton.scss
+++ b/src/components/AppButton/AppButton.scss
@@ -1,6 +1,5 @@
-/* All SFC styles live in the components layer so the utilities and
-   preferences layers can override them — see layers.css.
-   Library mixins are injected via Vite's additionalData, so no @use here. */
+/* SFC styles go in the components layer so utilities/preferences can override
+   them (see layers.css). Mixins come from Vite's additionalData, so no @use. */
 @layer components {
   .button {
     display: inline-flex;

--- a/src/components/AppDialog/AppDialog.vue
+++ b/src/components/AppDialog/AppDialog.vue
@@ -30,11 +30,9 @@ import { ref, useId } from 'vue'
 const dialog = ref<HTMLDialogElement | null>(null)
 const titleId = useId()
 
-// Native <dialog> + showModal() gives focus trapping, Esc-to-close,
-// inert background, and top-layer rendering for free. The closedby="any"
-// attribute adds light-dismiss (outside-click) natively too — no JS handler.
-// On browsers without closedby support the dialog still closes via Esc and
-// the close button; only outside-click degrades, which is harmless.
+// Native <dialog> + showModal() gives focus trapping, Esc-to-close, an inert
+// background, and top-layer rendering for free; closedby="any" adds native
+// outside-click dismiss. Without closedby support only outside-click degrades.
 defineExpose({
   open: () => dialog.value?.showModal(),
   close: () => dialog.value?.close(),

--- a/src/components/PillarHeader/PillarHeader.vue
+++ b/src/components/PillarHeader/PillarHeader.vue
@@ -1,11 +1,5 @@
 <template>
-  <!-- Opens a pillar like a chapter: a per-pillar mark, the numbered eyebrow,
-       the pillar title (the real <h2> for this region), and an optional lead.
-       The icon is decorative; the heading carries the accessible name. -->
   <header class="pillar-header">
-    <!-- Oversized echo of this pillar's mark, bleeding off the right edge as a
-         faint watermark. Purely decorative; static (no animation), so it costs
-         nothing at runtime. -->
     <span
       class="pillar-header-watermark"
       aria-hidden="true"
@@ -40,22 +34,16 @@ defineProps<{
     max-inline-size: 60ch;
   }
 
-  /* Icon and title ride on one line, centred on each other, so the mark
-     anchors the heading instead of floating above it. The eyebrow sits on its
-     own line above. */
   .pillar-header-top {
     display: flex;
     align-items: center;
     gap: var(--space-4);
   }
 
-  /* Pull the eyebrow close to the icon/title row it labels. */
   .pillar-header-eyebrow + .pillar-header-top {
     margin-block-start: calc(var(--space-4) * -1 + var(--space-2));
   }
 
-  /* App-icon style tile, echoing the favicon: the mark sits in a soft rounded
-     square so each pillar opens with a clear visual anchor. */
   .pillar-header-icon {
     display: inline-flex;
     flex-shrink: 0;
@@ -78,19 +66,16 @@ defineProps<{
     block-size: 2rem;
   }
 
-  /* The giant watermark: positioned against the .pillar (App.vue gives it
-     position: relative + isolation), bleeding off the right edge where
-     overflow-x: clip on the app shell hides the overspill — no scrollbar. Sits
-     at z-index -1, behind the chapter's content. Faint, so it never competes
-     with text; opaque demo cards paint over it entirely. */
+  /* Bleeds off the right edge of the .pillar (App.vue gives it position +
+     isolation); overflow-x: clip on the shell hides the overspill. z-index -1,
+     behind the chapter's content. */
   .pillar-header-watermark {
     position: absolute;
     z-index: -1;
     inset-block-start: -2rem;
     inset-inline-end: 0;
-    /* Mobile-first: smaller and pushed further off the edge. The narrow layout
-       has no side gutter, so a big mark would sit right under the text — this
-       keeps it a corner sliver and protects the contrast ratio. */
+    /* Mobile: smaller and pushed further off — the narrow layout has no gutter,
+       so a big mark would sit under the text. */
     inline-size: 16rem;
     block-size: 16rem;
     color: var(--color-primary);
@@ -98,19 +83,14 @@ defineProps<{
     transform: translateX(52%) rotate(-12deg);
     pointer-events: none;
 
-    /* Desktop: much larger, and bled further past the edge (the app shell's
-       overflow-x: clip hides the overspill, so there's still no scrollbar). */
     @include from('md') {
       inline-size: 36rem;
       block-size: 36rem;
       transform: translateX(46%) rotate(-12deg);
     }
 
-    /* Parallax: the mark drifts slower than the content for a sense of depth.
-       It animates the `translate` property only (composited, off the main
-       thread via the element's own view-timeline), so it adds no paint cost
-       while scrolling — unlike colour/gradient animation. Support + motion
-       gated; without either, the mark is simply static. */
+    /* Animates `translate` only, so the parallax stays composited — no paint
+       cost on scroll. Static where motion or view-timelines aren't available. */
     @media (prefers-reduced-motion: no-preference) {
       @supports (animation-timeline: view()) {
         animation: pillar-watermark-parallax linear both;
@@ -119,7 +99,6 @@ defineProps<{
       }
     }
 
-    /* Decorative flourish — drop it where the OS flattens the palette. */
     @include forced-colors {
       display: none;
     }
@@ -128,12 +107,9 @@ defineProps<{
   .pillar-header-watermark :deep(svg) {
     inline-size: 100%;
     block-size: 100%;
-    /* Thinner stroke reads better blown up to poster scale. */
     stroke-width: 1;
   }
 
-  /* Lag the mark behind the scroll — the `translate` runs opposite the travel,
-     so the watermark appears to move slower than the foreground. */
   @keyframes pillar-watermark-parallax {
     from {
       translate: 0 -30%;
@@ -152,7 +128,6 @@ defineProps<{
   }
 
   .pillar-header-title {
-    /* A mini-poster scale — smaller than the hero, larger than a section. */
     font-size: clamp(2rem, 5vw, 3rem);
     font-weight: 800;
     line-height: var(--leading-tight);

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -28,16 +28,12 @@
     background-color: var(--color-surface);
     color: var(--color-text);
 
-    /* Native validity from constraints (required, type="email", …).
-       :user-* (not :valid/:invalid) only match AFTER the user has
-       interacted, so pristine fields never flag. The thicker border on
-       the invalid state is a non-color cue, so it survives forced-colors.
-
-       Success only shows when the field has content: an empty optional
-       field is technically valid, but a green "all good" border there is
-       just noise. :placeholder-shown detects emptiness (hence the " "
-       default placeholder); :where() keeps the selector's specificity flat
-       so the explicit-error rule below still wins purely on source order. */
+    /* :user-* (not :valid/:invalid) only match after interaction, so pristine
+       fields never flag; the thicker invalid border is a non-colour cue that
+       survives forced-colors. Success shows only with content (an empty
+       optional field is valid but a green border there is noise) —
+       :placeholder-shown detects emptiness, :where() keeps specificity flat so
+       the explicit-error rule below still wins on source order. */
     &:user-valid:not(:where(:placeholder-shown)) {
       border-color: var(--color-success);
     }

--- a/src/components/TextField/TextField.vue
+++ b/src/components/TextField/TextField.vue
@@ -2,9 +2,7 @@
   <div class="field">
     <label class="field-label" :for="inputId">
       {{ label }}
-      <!-- Visual convention only; aria-hidden so screen readers don't read
-           "star". The required state is already conveyed natively by the
-           input's required attribute. -->
+      <!-- aria-hidden: decorative; the input's `required` already conveys the state to AT. -->
       <span v-if="required" class="field-required" aria-hidden="true">*</span>
     </label>
     <p v-if="hint" :id="hintId" class="field-hint">{{ hint }}</p>
@@ -34,12 +32,10 @@ const props = withDefaults(
     error?: string
     type?: string
     required?: boolean
-    // A regex (HTML pattern syntax) to tighten native validation beyond what
-    // the type alone checks. Stays in the native constraint pipeline, so
-    // :user-invalid styling and the browser's validation message just work.
+    // Regex (HTML pattern) tightening native validation beyond the type; stays
+    // in the constraint pipeline, so :user-invalid styling just works.
     pattern?: string
-    // Describes the expected format; shown in the browser's native validation
-    // popup when a pattern fails.
+    // Shown in the browser's native validation popup when the pattern fails.
     title?: string
     // Defaults to a single space so :placeholder-shown can act as an
     // "is empty" detector in CSS (see the .field-input styles).

--- a/src/craft/demos/LightDarkDemo.vue
+++ b/src/craft/demos/LightDarkDemo.vue
@@ -99,8 +99,7 @@
     background-color: light-dark(#1a1a2e, #e6e6fa);
   }
 
-  /* The legacy swatch: base value + a media-query override. Identical result,
-     authored as two separate declarations that have to be kept in sync. */
+  /* The legacy swatch: base value + media-query override — two declarations to keep in sync. */
   .light-dark-swatch-legacy {
     background-color: #1a1a2e;
 

--- a/src/criteria/ConformanceShift/ConformanceShift.scss
+++ b/src/criteria/ConformanceShift/ConformanceShift.scss
@@ -22,7 +22,6 @@
   }
 
   .conformance-shift-panels {
-    /* Two panels side by side when there's room, stacked when tight. */
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
     gap: var(--space-4);

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -9,8 +9,7 @@
     list-style: none;
   }
 
-  /* The continuous spine, centred in the markers' column. Fades toward the
-     bottom — the standard runs on into the (draft) future. */
+  /* The spine, centred in the marker column; fades out toward the bottom. */
   .timeline::before {
     content: '';
     position: absolute;
@@ -111,10 +110,8 @@
     }
   }
 
-  /* Scroll-morphing spine: an accent line "draws" down the timeline as you
-     scroll through it, and each marker pops in as its era arrives. Both are
-     scroll-driven (off the main thread) and progressive enhancement — added
-     only with motion allowed and view() timelines supported. */
+  /* Scroll-driven (off the main thread) flourishes — the accent spine draws
+     down and markers pop in as their era arrives. Motion- and support-gated. */
   @media (prefers-reduced-motion: no-preference) {
     @supports (animation-timeline: view()) {
       .timeline::after {
@@ -129,10 +126,8 @@
         transform-origin: top;
         animation: timeline-fill linear both;
         animation-timeline: view();
-        /* Spread the fill across (almost) the whole pass so it keeps drawing
-           down to the last era instead of completing early and scrolling its
-           leading edge off-screen. The end %% is the knob: higher = slower /
-           finishes later. */
+        /* Spread the fill across most of the pass so it keeps drawing to the
+           last era; the end % is the knob (higher = finishes later). */
         animation-range: cover 12% cover 96%;
       }
 
@@ -142,9 +137,7 @@
         animation-range: entry 0% cover 12%;
       }
 
-      /* Each criterion card glides in from the right as it enters the
-         viewport. The cards live inside the child CriterionFrame component, so
-         reach them with :deep(). */
+      /* Cards glide in on entry; they live in the child component, so :deep(). */
       /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
       :deep(.criterion) {
         animation: era-slide-in linear both;

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
@@ -1,6 +1,5 @@
 <template>
-  <!-- Ordered list: the eras are chronological, and that sequence is the
-       point. The spine and markers are decorative (CSS only). -->
+  <!-- <ol>: the era order is chronological and meaningful. Spine/markers are decorative. -->
   <ol class="timeline">
     <li
       v-for="era in eras"
@@ -48,8 +47,7 @@
 import CriterionFrame from '../CriterionFrame/CriterionFrame.vue'
 import { criteria, wcagTimeline } from '../registry'
 
-// Group the criteria under their WCAG version; eras with no version stay
-// empty and render their note instead.
+// Group criteria by WCAG version; version-less eras stay empty and show their note.
 const eras = wcagTimeline.map((era) => ({
   ...era,
   items: era.version ? criteria.filter((c) => c.version === era.version) : [],

--- a/src/criteria/CriterionFrame/CriterionFrame.vue
+++ b/src/criteria/CriterionFrame/CriterionFrame.vue
@@ -14,9 +14,8 @@
 
     <p class="criterion-requirement">{{ requirement }}</p>
 
-    <!-- The demo is compliant by default. `broken` is handed to the demo
-         via the slot prop so it can regress its OWN styles; the wrapper
-         class is just for the frame's danger outline. -->
+    <!-- `broken` passes to the demo via the slot prop so it regresses its own
+         styles; the wrapper class is just the frame's danger outline. -->
     <div class="criterion-demo" :class="{ 'is-broken': broken }">
       <slot :broken="broken" />
     </div>
@@ -60,11 +59,9 @@ const props = withDefaults(
     version: string // e.g. "WCAG 2.2"
     principle: string // Perceivable | Operable | …
     requirement: string
-    // What the toggle does, and what it says once broken.
     breakLabel?: string
     restoreLabel?: string
-    // Each criterion explains its own pass / fail state — the failure text
-    // is the teaching moment.
+    // Pass/fail copy per criterion — the failure text is the teaching moment.
     passText: string
     failText: string
     links?: CriterionLink[]

--- a/src/criteria/LegalMap/LegalMap.scss
+++ b/src/criteria/LegalMap/LegalMap.scss
@@ -5,8 +5,6 @@
     gap: var(--space-6);
   }
 
-  /* The core sits above the laws; the accent gradient marks it as the thing
-     everything else references. */
   .legal-map-core {
     display: grid;
     gap: var(--space-1);

--- a/src/criteria/demos/AnimationDemo.vue
+++ b/src/criteria/demos/AnimationDemo.vue
@@ -12,8 +12,7 @@
     </label>
 
     <div class="animation-stage">
-      <!-- :key remounts the panel on each click, replaying the CSS entry
-           animation — a clean interaction-triggered motion. -->
+      <!-- :key remounts the panel on each click, replaying the entry animation. -->
       <article :key="playId" class="animation-panel">
         <p class="animation-panel-title">Message sent</p>
         <p class="animation-panel-text">Your changes are saved.</p>
@@ -40,9 +39,8 @@ const playId = ref(0)
 <style scoped lang="scss">
 @layer components {
   .animation-demo {
-    /* One switch governs all motion: 0 = motion allowed, 1 = suppressed.
-       The compliant cascade flips it to 1 when the preference is set
-       (simulated OR real); the broken state forces it back to 0. */
+    /* One switch for all motion: 0 = allowed, 1 = suppressed. Compliant flips
+       it to 1 on the preference (simulated or real); broken forces it to 0. */
     --rm: 0;
 
     display: grid;

--- a/src/criteria/demos/FocusAppearanceDemo.vue
+++ b/src/criteria/demos/FocusAppearanceDemo.vue
@@ -50,9 +50,8 @@ const actions = ['Save', 'Duplicate', 'Archive', 'Delete']
     font-weight: 600;
     cursor: pointer;
 
-    /* Compliant: nothing here. The foundation's global *:focus-visible ring
-       (preferences layer — the thick, offset, high-contrast token ring)
-       already applies and easily meets 2.4.13. */
+    /* Compliant: nothing here — the foundation's global *:focus-visible ring
+       (preferences layer) already applies and meets 2.4.13. */
 
     @include high-contrast {
       border-color: currentcolor;
@@ -63,11 +62,9 @@ const actions = ['Save', 'Duplicate', 'Archive', 'Delete']
     }
   }
 
-  /* The regression: a hairline, low-contrast, zero-offset outline. Because
-     the foundation's ring lives in the preferences layer (which wins over
-     components), the only way to defeat it is the classic anti-pattern —
-     overriding with !important. That this takes !important IS the lesson:
-     the foundation protects the ring; you have to actively fight it to fail. */
+  /* The regression: a hairline, zero-offset outline. The foundation's ring
+     lives in the preferences layer (which wins over components), so defeating
+     it takes !important — that it does IS the lesson: you must fight to fail. */
   .is-broken {
     .focus-appearance-btn:focus-visible {
       /* stylelint-disable declaration-no-important -- deliberately simulating the anti-pattern */

--- a/src/criteria/demos/FocusObscuredDemo.vue
+++ b/src/criteria/demos/FocusObscuredDemo.vue
@@ -92,10 +92,8 @@ const items = [
     }
   }
 
-  /* The regression: drop the scroll offset so a link tabbed to near the
-     top scrolls flush under the sticky bar — the focus ring ends up hidden
-     behind it. Nothing else changes; focus still moves correctly, you just
-     can't see where it is. */
+  /* The regression: drop the scroll offset, so a link tabbed near the top
+     scrolls flush under the sticky bar and its focus ring is hidden. */
   .is-broken {
     .focus-obscured-link {
       scroll-margin-block-start: 0;

--- a/src/criteria/demos/NonTextContrastDemo.vue
+++ b/src/criteria/demos/NonTextContrastDemo.vue
@@ -32,10 +32,9 @@ const chips = ['Unread', 'Starred']
 <style scoped lang="scss">
 @layer components {
   .non-text-contrast-demo {
-    /* The single border color the controls share. Compliant value sits at
-       ~3.5:1 against the surface in both themes; the broken override drops
-       it to ~1.2:1. Hardcoded here because the contrast ratio IS the
-       subject of the demo — not part of the design-token system. */
+    /* Shared control border. Compliant ~3.5:1 vs the surface in both themes;
+       broken drops it to ~1.2:1. Hardcoded because the ratio IS the demo's
+       subject, not a design token. */
     --demo-border: light-dark(#8a8a8a, #8f8f8f);
 
     display: grid;
@@ -63,8 +62,7 @@ const chips = ['Unread', 'Starred']
     color: var(--color-text);
 
     @include forced-colors {
-      /* Forced-colors is the OS-level safety net: it overrides author
-         colors entirely, so these controls stay visible no matter what. */
+      /* Forced-colors safety net: overrides author colours, so controls stay visible. */
       border-color: ButtonText;
     }
   }
@@ -104,9 +102,8 @@ const chips = ['Unread', 'Starred']
     }
   }
 
-  /* The regression: wash the shared border color down to ~1.2:1 against
-     the surface. Nothing else changes — the controls keep their size,
-     labels, and behaviour; only the contrast of their boundary fails. */
+  /* The regression: wash the shared border down to ~1.2:1. Nothing else
+     changes — only the boundary's contrast fails. */
   .is-broken {
     --demo-border: light-dark(#ededed, #292929);
   }

--- a/src/criteria/demos/OrientationDemo.vue
+++ b/src/criteria/demos/OrientationDemo.vue
@@ -9,9 +9,7 @@
 
     <div class="orientation-stage">
       <div class="orientation-device">
-        <!-- Both states are always in the DOM; CSS shows the right one for
-             the current orientation + rule state, so only orientation
-             handling changes between compliant and broken. -->
+        <!-- Both states stay in the DOM; CSS shows the right one per orientation + rule state. -->
         <div class="orientation-screen">
           <p class="orientation-screen-title">Today</p>
           <p class="orientation-screen-row">7,204 steps</p>
@@ -74,8 +72,7 @@ const landscape = ref(false)
     }
   }
 
-  /* Rotating swaps the device's dimensions. The .is-landscape class lives
-     on the demo root, so the device is targeted as a descendant. */
+  /* Rotating swaps the device's dimensions (.is-landscape sits on the root). */
   .is-landscape .orientation-device {
     inline-size: 17rem;
     block-size: 11rem;

--- a/src/criteria/demos/ReflowDemo.vue
+++ b/src/criteria/demos/ReflowDemo.vue
@@ -5,10 +5,9 @@
       to 400%, which is the width 1.4.10 targets. Scroll it.
     </p>
 
-    <!-- A simulated narrow viewport. overflow:auto contains any scrolling
-         to this box (not the page), so a horizontal scrollbar appearing
-         here IS the failure you can see and feel. It's keyboard-focusable so
-         the scrollable area is reachable without a pointer. -->
+    <!-- Simulated narrow viewport: overflow:auto keeps scrolling local, so a
+         horizontal scrollbar here IS the visible failure. Focusable so the
+         scroll area is keyboard-reachable. -->
     <div
       class="reflow-viewport"
       tabindex="0"
@@ -126,10 +125,9 @@ const stats = [
     color: var(--color-text-subtle);
   }
 
-  /* The regression: fixed widths that ignore the viewport. The content
-     becomes wider than its container, so reading now requires scrolling
-     in two dimensions — exactly what 1.4.10 forbids. Only the sizing
-     changes; the content and structure are identical. */
+  /* The regression: fixed widths force the content wider than its container, so
+     reading needs two-dimensional scrolling — what 1.4.10 forbids. Sizing only;
+     content and structure are unchanged. */
   .is-broken {
     .reflow-content {
       inline-size: 34rem;

--- a/src/criteria/demos/TargetSizeDemo.vue
+++ b/src/criteria/demos/TargetSizeDemo.vue
@@ -93,9 +93,8 @@ const active = reactive({})
     }
   }
 
-  /* The regression: drop well under 24px and remove the spacing, so the
-     targets become cramped and easy to mis-tap. Nothing else changes —
-     the buttons keep their labels and semantics; only 2.5.8 is violated. */
+  /* The regression: drop well under 24px and remove spacing, so targets are
+     cramped and easy to mis-tap; only 2.5.8 is violated. */
   .is-broken {
     .target-size-toolbar {
       gap: 0;

--- a/src/criteria/registry.ts
+++ b/src/criteria/registry.ts
@@ -1,21 +1,13 @@
 /**
- * Criteria registry — the "guidelines, alive" section.
+ * Criteria registry — the "guidelines, alive" section. Each entry is a WCAG
+ * criterion this foundation satisfies, paired with a demo whose compliance can
+ * be toggled OFF (CriterionFrame's "break it" switch) so visitors feel what it
+ * prevents. App.vue renders the list.
  *
- * Each entry is a WCAG success criterion that this foundation already
- * satisfies, paired with a live demo whose compliance can be toggled OFF
- * (the "break it" switch in CriterionFrame) so the visitor *feels* what the
- * criterion prevents — not just reads its definition.
- *
- * To add a criterion:
- *   1. Build a demo in ./demos/ that is compliant by default and accepts a
- *      `broken` prop; in its scoped styles, an `.is-broken` block regresses
- *      ONLY the behaviour this criterion governs (keep semantics intact).
- *   2. Add an entry here. App.vue renders the list.
- *
- * Scope discipline: prefer criteria that (a) the foundation already
- * implements and (b) are recent additions (WCAG 2.1 / 2.2) — the "new"
- * material that design-system docs rarely cover. Don't try to cover all
- * ~80 criteria.
+ * To add one: build a demo in ./demos/ that's compliant by default and takes a
+ * `broken` prop whose `.is-broken` block regresses ONLY this criterion's
+ * behaviour (semantics intact), then add an entry. Prefer recent criteria
+ * (WCAG 2.1 / 2.2) the foundation already implements; don't cover all ~80.
  *
  * Sources: https://www.w3.org/WAI/WCAG22/Understanding/
  */
@@ -240,12 +232,8 @@ export const criteria: Criterion[] = [
 ]
 
 
-/* ===========================================================================
-   WCAG timeline — the narrative spine. Each era groups the criteria above by
-   their `version`; eras with no demos (the 2.0 foundation, the 3.0 draft)
-   carry a `note` instead. This is what turns the flat list into the "watch
-   the standard grow" story.
-=========================================================================== */
+/* WCAG timeline — groups the criteria above by `version`; eras with no demos
+   (2.0 foundation, 3.0 draft) carry a `note` instead. */
 
 export interface WcagEra {
   id: string

--- a/src/icons/heroIcons.ts
+++ b/src/icons/heroIcons.ts
@@ -1,10 +1,9 @@
 /**
- * Hero glyphs — decorative wayfinding pictograms + accessibility concepts.
+ * Hero glyphs — decorative wayfinding pictograms + accessibility concepts,
+ * shared viewBox "0 -960 960 960", rendered aria-hidden (decorative only).
  *
  * Source: Material Symbols (outlined, weight 400) by Google.
  * License: Apache License 2.0 — https://github.com/google/material-design-icons
- * All icons share the viewBox "0 -960 960 960". They are decorative only
- * (rendered aria-hidden); the <h1> carries the page's meaning.
  */
 
 export interface HeroIcon {

--- a/src/icons/pillarIcons.ts
+++ b/src/icons/pillarIcons.ts
@@ -1,11 +1,6 @@
 /**
- * Pillar marks — the four decorative line icons, one per pillar.
- *
- * Stroke-based so they echo the brand's focus-ring motif, on a shared 24×24
- * geometry so the set reads as one family. Used twice: as each pillar's small
- * header tile, and — blown up, faint, and rotated — as the oversized
- * watermarks behind the hero and each pillar. Decorative only (always
- * rendered aria-hidden); the headings carry the accessible names.
+ * The four pillar marks — shared by PillarHeader (small header tile) and the
+ * hero (oversized watermark). Decorative; always rendered aria-hidden.
  */
 const svg = (paths: string) =>
   `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`

--- a/src/legal/legal.scss
+++ b/src/legal/legal.scss
@@ -1,6 +1,5 @@
-/* Layout for the standalone legal pages (Impressum, Privacy). Wrapped in the
-   components layer so it follows the project's "no unlayered CSS" rule and
-   loses to user-preference layers like everything else. */
+/* Layout for the standalone legal pages (Impressum, Privacy). In the components
+   layer (the project's "no unlayered CSS" rule). */
 @layer components {
   .legal {
     max-inline-size: 70ch;

--- a/src/showcases/CodeBlock/CodeBlock.vue
+++ b/src/showcases/CodeBlock/CodeBlock.vue
@@ -12,9 +12,8 @@
       </button>
     </figcaption>
 
-    <!-- tabindex makes the code keyboard-scrollable when a line overflows.
-         v-html is safe here: the source is our own escaped snippet text, with
-         only <span>s added around comments so they can be visually muted. -->
+    <!-- tabindex makes overflowing code keyboard-scrollable. v-html is safe:
+         the source is our own escaped text, with <span>s only around comments. -->
     <pre class="code-block-pre" tabindex="0"><code v-html="highlighted" /></pre>
 
     <!-- Announces the copy result to screen readers without moving focus. -->
@@ -35,10 +34,9 @@ const props = defineProps<{
 const trimmed = computed(() => props.code.replace(/\s+$/, ''))
 
 /**
- * Escape the snippet, then wrap comments so the stylesheet can mute them and
- * let the actual code carry the emphasis. Not a syntax highlighter: comments
- * only, and the pattern is per-language so we never mistake `//` inside an
- * HTML URL (or a CSS value) for a comment.
+ * Escape the snippet, then wrap comments so the stylesheet can mute them. Not a
+ * syntax highlighter — comments only, per-language so `//` inside an HTML URL
+ * isn't mistaken for one.
  */
 const commentPattern = computed(() => {
   if (props.label === 'JS') return /(\/\*[\s\S]*?\*\/|\/\/[^\n]*)/g

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
@@ -8,8 +8,7 @@
     border-radius: var(--radius-lg);
     background-color: var(--color-surface);
     box-shadow: var(--shadow-md);
-    /* A soft elevation lift only — no transform or border flash. Motion
-       tokens are zeroed under reduced motion, so it settles instantly there. */
+    /* Elevation lift only. Motion tokens are zeroed under reduced motion. */
     transition: box-shadow var(--duration-normal) var(--easing-standard);
 
     @include can-hover {
@@ -18,7 +17,7 @@
       }
     }
 
-    /* Same affordance when focus moves into the card (keyboard, any device). */
+    /* Same lift when focus enters the card. */
     &:focus-within {
       box-shadow: var(--shadow-lg);
     }
@@ -84,9 +83,8 @@
     border-radius: var(--radius-md);
   }
 
-  /* "Show the code" disclosure — a native <details>, so keyboard and
-     screen-reader behaviour (and the expanded state) come for free, no JS.
-     Styled as a clear button-like affordance so it reads as a feature. */
+  /* "Show the code" — a native <details>, so keyboard/SR behaviour and the
+     expanded state come for free; styled as a button-like affordance. */
   .showcase-code-summary {
     display: inline-flex;
     align-items: center;
@@ -125,7 +123,7 @@
   .showcase-code-glyph {
     inline-size: 1.15em;
     block-size: 1.15em;
-    color: var(--color-primary); // accent the code mark
+    color: var(--color-primary);
   }
 
   .showcase-code-chevron {
@@ -139,8 +137,7 @@
     rotate: 180deg;
   }
 
-  /* Swap the label with the open state — pure CSS, and display:none keeps the
-     hidden one out of the accessible name too. */
+  /* Swap the label on open — display:none keeps the hidden one out of the a11y name. */
   .showcase-code-label-hide {
     display: none;
   }

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
@@ -82,18 +82,9 @@ const props = withDefaults(
   defineProps<{
     title: string
     summary: string
-    /**
-     * 'stable'   — interoperable across current browsers (Baseline / past
-     *              Interop rounds). Safe to rely on.
-     * 'emerging' — current Interop focus area or partial support. Always
-     *              ship behind @supports with a usable fallback.
-     */
+    /** 'stable' = interoperable now; 'emerging' = Interop area / partial support. */
     status?: 'stable' | 'emerging'
-    /**
-     * A CSS.supports() condition for the feature being demonstrated, e.g.
-     * "container-type: inline-size". Tells the visitor whether they're
-     * seeing the feature or its fallback.
-     */
+    /** CSS.supports() condition for the feature, e.g. "container-type: inline-size". */
     supports?: string
     links?: ShowcaseLink[]
     /** Match the surrounding document outline (4 = under an h3 group). */

--- a/src/showcases/demos/AnchorPopoverDemo/AnchorPopoverDemo.vue
+++ b/src/showcases/demos/AnchorPopoverDemo/AnchorPopoverDemo.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="anchor-demo">
-    <!-- popover + popovertarget: open/close, Esc-to-dismiss, light
-         dismiss, and aria-expanded all come from the platform — zero JS.
-         Attributes fall through to AppButton's <button>. -->
+    <!-- popover + popovertarget: open/close, Esc, light-dismiss, aria-expanded
+         all from the platform — zero JS. Attrs fall through to AppButton's <button>. -->
     <AppButton
       variant="secondary"
       class="anchor-trigger"
@@ -50,21 +49,15 @@ const popoverId = useId()
 
     /* The enhancement, only where the feature exists. */
     @supports (anchor-name: --a) {
-      /* Keep the UA popover's `position: fixed`, NOT absolute. With absolute,
-         the containing block becomes the nearest positioned ancestor
-         (.app-shell is `position: relative` and full-page-tall), so the panel
-         never "overflows" at the viewport edge and the flip fallbacks never
-         fire. Fixed resolves against the viewport, so flipping works. */
+      /* Keep `position: fixed`, NOT absolute. Absolute would resolve against
+         .app-shell (positioned, full-page-tall), so the panel never overflows
+         the viewport edge and the flip fallbacks never fire. */
       position: fixed;
       position-anchor: --showcase-anchor;
       position-area: block-end span-inline-end;
-      /* Clear the UA popover centering (inset: 0; margin: auto) — left in
-         place it fights position-area and the panel renders centered
-         instead of anchored. */
+      /* Clear the UA centering (inset:0; margin:auto) or it fights position-area. */
       inset: auto;
-      /* Try in order until one fits: flip below↔above, flip the inline
-         side, then flip both for the corner case. The browser keeps the
-         panel on-screen with no JS and no scroll listeners. */
+      /* Try until one fits: flip block, flip inline, then both for the corner. */
       position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
       margin: var(--space-2) 0 0;
     }

--- a/src/showcases/demos/AnchorTooltipDemo/AnchorTooltipDemo.vue
+++ b/src/showcases/demos/AnchorTooltipDemo/AnchorTooltipDemo.vue
@@ -236,8 +236,7 @@
 
     .anchor-tooltip-bubble {
       /* Fixed + anchor positions against the trigger in the viewport, so the
-         hint follows on scroll AND can't be clipped by the card's overflow —
-         which absolute-in-a-relative-wrapper can't guarantee. */
+         hint follows on scroll and can't be clipped by the card's overflow. */
       position: fixed;
       inset: auto;
       translate: none;

--- a/src/showcases/demos/AttrDemo/AttrDemo.vue
+++ b/src/showcases/demos/AttrDemo/AttrDemo.vue
@@ -83,9 +83,8 @@ const metrics = [
     /* Fallback today: a custom property mirrors the data value. */
     inline-size: calc(var(--v, 0) * 1%);
 
-    /* The point of the feature: read it straight from the attribute, with
-       no inline style or JS at all. (Sass reads the <number> type as
-       comparison operators, so its operator rule is silenced here.) */
+    /* The feature: read straight from the attribute, no inline style or JS.
+       (Sass reads the <number> type as operators, so that rule is silenced.) */
     /* stylelint-disable scss/operator-no-unspaced */
     @supports (width: calc(attr(data-value type(<number>), 0) * 1%)) {
       inline-size: calc(attr(data-value type(<number>), 0) * 1%);

--- a/src/showcases/demos/ContainerCardDemo/ContainerCardDemo.vue
+++ b/src/showcases/demos/ContainerCardDemo/ContainerCardDemo.vue
@@ -12,13 +12,10 @@
       <span aria-hidden="true">{{ width }}%</span>
     </label>
 
-    <!-- The container under test. Width is driven by the slider above
-         (keyboard-accessible, unlike a CSS resize handle), so you can
-         watch the cards respond to their container — the viewport never
-         changes. -->
+    <!-- Width driven by the slider (keyboard-accessible, unlike a resize handle),
+         so the cards respond to their container, not the viewport. -->
     <div class="container-query-stage" :style="{ inlineSize: `${width}%` }">
-      <!-- The wrapper is the container, the card inside responds to it.
-           A container can't query itself — only its descendants can. -->
+      <!-- The wrapper is the container; a container can't query itself, only descendants. -->
       <div v-for="card in cards" :key="card.title" class="card-cell">
         <article class="card">
           <div class="card-swatch" aria-hidden="true"></div>

--- a/src/showcases/demos/ContrastColorDemo/ContrastColorDemo.vue
+++ b/src/showcases/demos/ContrastColorDemo/ContrastColorDemo.vue
@@ -47,9 +47,8 @@ const bg = ref('#2563eb')
     background-color: var(--swatch-bg);
     font-weight: 600;
 
-    /* Fallback: fixed light text with a shadow — readable on most picks,
-       but the user can defeat it. That's the problem contrast-color()
-       solves: the browser guarantees a contrasting color. */
+    /* Fallback: fixed light text + shadow — readable on most picks, but the
+       user can defeat it. contrast-color() guarantees a contrasting colour. */
     color: var(--color-primary-text);
     text-shadow: 0 1px 2px rgb(0 0 0 / 60%);
 

--- a/src/showcases/demos/CustomSelectDemo/CustomSelectDemo.vue
+++ b/src/showcases/demos/CustomSelectDemo/CustomSelectDemo.vue
@@ -14,9 +14,8 @@
     <label class="custom-select-field">
       <span class="custom-select-label">Task status</span>
 
-      <!-- A button + <selectedcontent> is the styleable display face in
-           base-select mode; legacy browsers ignore them and render the plain
-           native control instead. -->
+      <!-- The button + <selectedcontent> is the styleable face in base-select
+           mode; legacy browsers ignore them and render the plain control. -->
       <select id="custom-select-status" name="status" class="custom-select">
         <button type="button" class="custom-select-trigger">
           <selectedcontent class="custom-select-value"></selectedcontent>
@@ -84,8 +83,7 @@
     font-weight: 600;
   }
 
-  /* Baseline styling that applies in BOTH modes — even the native fallback
-     gets a tidy border, padding, and the theme's colours. */
+  /* Baseline styling for both modes — even the native fallback gets a tidy border. */
   .custom-select {
     padding: var(--space-2) var(--space-3);
     border: 1px solid var(--color-border);
@@ -99,9 +97,8 @@
     }
   }
 
-  /* The enhancement: opt the control AND its picker popup into full styling.
-     Everything below only takes effect where base-select is supported; the
-     markup degrades to a normal native select otherwise. */
+  /* The enhancement: opt the control and its picker popup into full styling,
+     only where base-select is supported (degrades to a native select). */
   @supports (appearance: base-select) {
     /* stylelint-disable property-no-unknown -- emerging customizable-select syntax */
     .custom-select,
@@ -118,9 +115,8 @@
       cursor: pointer;
     }
 
-    /* The trigger fully coincides with the <select> box (same width, ≥44px
-       tall) so the control reads as ONE target — not a sliver of select
-       peeking past a smaller button, which trips target-size checks. */
+    /* Trigger fully covers the <select> box (full width, ≥44px) so it's ONE
+       target — no select sliver peeking past a smaller button (target size). */
     .custom-select-trigger {
       display: flex;
       align-items: center;
@@ -148,8 +144,8 @@
       }
     }
 
-    /* The selected option's content is mirrored into <selectedcontent>; hide
-       the long description there so the closed control stays compact. */
+    /* Selected content is mirrored into <selectedcontent>; hide the long
+       description so the closed control stays compact. */
     .custom-select-value {
       flex: 1;
 
@@ -158,8 +154,7 @@
       }
     }
 
-    /* The UA renders its own ::picker-icon (outside our button, on its own
-       line) — hide it and use one custom arrow inside the trigger instead. */
+    /* Hide the UA's ::picker-icon; use our own arrow inside the trigger. */
     .custom-select::picker-icon {
       display: none;
     }
@@ -177,12 +172,10 @@
       rotate: 225deg;
     }
 
-    /* The dropdown popup. base-select auto-anchors it to the control, so no
-       manual anchor wiring — just style it like any surface. */
+    /* The popup — base-select auto-anchors it, so no manual anchor wiring. */
     .custom-select::picker(select) {
       margin-block-start: var(--space-1);
-      /* Keep a generous floor before the popup shrinks-and-scrolls or flips to
-         the other side — it only gives way when there's genuinely no room. */
+      /* Generous floor before the popup shrinks/flips — gives way only when there's no room. */
       min-block-size: 12rem;
       padding: var(--space-1);
       border: 1px solid var(--color-border);
@@ -209,8 +202,7 @@
       }
     }
 
-    /* The active option already shows a checkmark; tint it so the current
-       value reads at a glance (never colour alone — the ✓ carries it too). */
+    /* Tint the active option so it reads at a glance (never colour alone — the ✓ carries it). */
     .custom-select option:checked {
       background-color: color-mix(in oklch, var(--color-primary) 14%, transparent);
 
@@ -231,8 +223,7 @@
       }
     }
 
-    /* A soft open/close fade on the popup. It rides the motion tokens, which
-       are zeroed under reduced-motion globally — so no override needed here. */
+    /* Open/close fade on the popup — rides the motion tokens (zeroed under reduced motion). */
     .custom-select::picker(select) {
       opacity: 0;
       transition:

--- a/src/showcases/demos/HasSelectorDemo/HasSelectorDemo.vue
+++ b/src/showcases/demos/HasSelectorDemo/HasSelectorDemo.vue
@@ -61,15 +61,13 @@ const selected = ref<string[]>([])
       border-color var(--duration-fast) var(--easing-standard),
       background-color var(--duration-fast) var(--easing-standard);
 
-    /* Transient: the row is being interacted with. The checkbox keeps its
-       own native focus ring — this is just a soft backdrop, the job
-       :focus-within is actually meant for. */
+    /* Transient: a soft backdrop while focused — the job :focus-within is for.
+       The checkbox keeps its own native focus ring. */
     &:focus-within {
       background-color: var(--color-bg-subtle);
     }
 
-    /* Persistent: the row is selected — :has() reaching its descendant's
-       checked state. This is the part :focus-within can't replicate. */
+    /* Persistent: selected via :has(:checked) — what :focus-within can't do. */
     &:has(:checked) {
       border-color: var(--color-primary);
       background-color: var(--color-bg-subtle);

--- a/src/showcases/demos/HighlightApiDemo/HighlightApiDemo.vue
+++ b/src/showcases/demos/HighlightApiDemo/HighlightApiDemo.vue
@@ -131,9 +131,8 @@ watch(query, update)
 }
 </style>
 
-<!-- ::highlight() is a global, named pseudo-element — it isn't tied to a
-     scoped element, so this rule lives in a plain (unscoped) block. The
-     highlight name is unique to this demo to avoid colliding with others. -->
+<!-- ::highlight() is a global pseudo-element (not scoped), so this rule lives
+     in an unscoped block; the name is unique to avoid collisions. -->
 <style lang="scss">
 @layer components {
   ::highlight(a11y-search) {

--- a/src/showcases/demos/PopoverMenuDemo/PopoverMenuDemo.vue
+++ b/src/showcases/demos/PopoverMenuDemo/PopoverMenuDemo.vue
@@ -111,10 +111,8 @@ const items = [
     /* Tether the menu to its trigger. Without anchor support it falls back
        to the UA popover placement (top-layer, centered) — still usable. */
     @supports (anchor-name: --a) {
-      /* Stay `position: fixed` (the UA popover default). With absolute, the
-         containing block would be the full-height .app-shell (position:
-         relative), so the menu never overflows the viewport edge and the
-         flip fallbacks never fire. Fixed resolves against the viewport. */
+      /* Stay `position: fixed`. Absolute would resolve against the full-height
+         .app-shell, so the menu never overflows the edge and flips never fire. */
       position: fixed;
       position-anchor: --popover-menu-anchor;
       /* Drop below the trigger, aligned to its inline-start edge. */

--- a/src/showcases/demos/ScrollProgressDemo/ScrollProgressDemo.vue
+++ b/src/showcases/demos/ScrollProgressDemo/ScrollProgressDemo.vue
@@ -1,6 +1,5 @@
 <template>
-  <!-- tabindex + role + label make the scroll region keyboard-operable
-       and announced — a scrollable div without these is mouse-only. -->
+  <!-- tabindex + role + label make the scroll region keyboard-operable and announced. -->
   <div
     class="scroll-demo"
     tabindex="0"
@@ -43,10 +42,8 @@
     background-color: var(--color-primary);
     transform-origin: 0 50%;
 
-    /* Hidden unless the browser can drive it from scroll position —
-       a frozen bar would read as "0% progress", which is worse than
-       no bar. Scroll-driven motion mirrors the user's own gesture,
-       so it needs no reduced-motion override. */
+    /* Hidden unless the browser can drive it from scroll — a frozen bar would
+       read as "0%". Scroll-linked motion mirrors the gesture, so no RM override. */
     display: none;
 
     @supports (animation-timeline: scroll()) {

--- a/src/showcases/demos/ScrollSnapDemo/ScrollSnapDemo.vue
+++ b/src/showcases/demos/ScrollSnapDemo/ScrollSnapDemo.vue
@@ -9,9 +9,8 @@
       forces <code>scroll-behavior: auto</code> there).
     </p>
 
-    <!-- The scroller is the focusable region; the cards stay a real list
-         inside it, so screen readers still announce "list, 5 items" (a
-         role="region" on the <ul> itself would strip that list semantics). -->
+    <!-- Scroller is the focusable region; the cards stay a list inside it (role
+         on the <ul> would strip "list, 5 items"). -->
     <div
       class="snap-track"
       tabindex="0"
@@ -57,8 +56,7 @@ const cards = [
     scroll-snap-type: x mandatory;
     overscroll-behavior-x: contain;
 
-    /* It's a focusable scroll container, so give it the same ring as
-       everything else — the foundation only auto-rings :focus-visible. */
+    /* Focusable scroll container — give it the standard focus ring. */
     border-radius: var(--radius-md);
 
     &:focus-visible {

--- a/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
+++ b/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
@@ -11,8 +11,7 @@
     <!-- snapped: the centered card highlights itself -->
     <section class="scroll-state-block">
       <h5 class="scroll-state-h">Snapped</h5>
-      <!-- Region wraps the list so the cards keep list semantics (a
-           role="region" directly on the <ul> would strip them). -->
+      <!-- Region wraps the list so the cards keep list semantics (role on the <ul> would strip them). -->
       <div
         class="scroll-state-track"
         tabindex="0"

--- a/src/showcases/demos/ShapeDemo/ShapeDemo.vue
+++ b/src/showcases/demos/ShapeDemo/ShapeDemo.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="shape-demo">
     <article class="shape-card">
-      <!-- Purely decorative: the curved band carries no text, so if its
-           background vanishes in forced-colors mode no information is lost. -->
+      <!-- Decorative: the band carries no text, so losing it in forced-colors loses nothing. -->
       <div class="shape-banner" aria-hidden="true">
         <span class="shape-banner-glyph">◗</span>
       </div>
@@ -50,10 +49,8 @@
     background: var(--gradient-accent);
     color: #fff;
 
-    /* The enhancement: a curved bottom edge. Falls back to a plain
-       rectangular band where shape() isn't supported. (The test needs a
-       command — `shape(from 0 0)` alone is invalid, so it would always
-       report false.) */
+    /* Curved bottom edge; falls back to a plain band without shape(). The
+       @supports test needs a command — `shape(from 0 0)` alone is invalid. */
     @supports (clip-path: shape(from 0 0, line to 100% 0)) {
       clip-path: shape(
         from 0 0,

--- a/src/showcases/demos/SlidingIndicatorDemo/SlidingIndicatorDemo.vue
+++ b/src/showcases/demos/SlidingIndicatorDemo/SlidingIndicatorDemo.vue
@@ -68,10 +68,8 @@ const view = ref(options[0])
     }
   }
 
-  /* The one continuous object. Its width is a single cell; translating by
-     i × 100% steps it from option to option. The transition uses a motion
-     token, which preferences.css zeroes under reduced motion — so the slide
-     becomes an instant jump with no per-component override. */
+  /* The one continuous pill: one cell wide, translated by i × 100% per option.
+     The motion token is zeroed under reduced motion, so the slide jumps instantly. */
   .segmented-indicator {
     position: absolute;
     z-index: 0;
@@ -118,8 +116,7 @@ const view = ref(options[0])
     color: var(--color-text-subtle);
   }
 
-  /* The selected option's label firms up — state isn't carried by the pill
-     position alone. */
+  /* Selected label firms up — state isn't carried by pill position alone. */
   .segmented-opt:has(input:checked) .segmented-label {
     font-weight: 600;
     color: var(--color-text);

--- a/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.vue
+++ b/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.vue
@@ -15,9 +15,8 @@
       <span>Add non-color cues</span>
     </label>
 
-    <!-- No JS: --cues is set on the demo root in CSS, where :has() reads this
-         checkbox. It inherits down to each status, where the style query reads
-         it and adds shapes to statuses that don't know about it. -->
+    <!-- No JS: :has() flips --cues on the root; it inherits down to each status,
+         where the style query reads it and adds shapes. -->
     <ul class="service-list">
       <li v-for="s in services" :key="s.name" class="service">
         <span class="service-name">{{ s.name }}</span>
@@ -52,9 +51,7 @@ const services: { name: string; state: State }[] = [
 <style scoped lang="scss">
 @layer components {
   .cues-demo {
-    /* The toggle's state lives here, set purely in CSS: :has() reads the
-       checkbox and flips --cues, which inherits down to every status where
-       the style query below reads it. No JS drives this. */
+    /* :has() reads the checkbox and flips --cues (inherits to every status). */
     --cues: off;
 
     display: grid;
@@ -127,10 +124,8 @@ const services: { name: string; state: State }[] = [
     }
   }
 
-  /* The container style query: when --cues is on (inherited from .cues-demo),
-     swap the colored dot for a colored SHAPE on the neutral row — a cue that
-     survives any color-vision deficiency. No status element references
-     --cues; the query reaches them from their ancestor. */
+  /* Style query: when --cues is on (inherited), swap the dot for a SHAPE that
+     survives any colour-vision deficiency — no status element references --cues. */
   @container style(--cues: on) {
     .service-status {
       background-color: transparent;

--- a/src/showcases/demos/SubgridDemo/SubgridDemo.vue
+++ b/src/showcases/demos/SubgridDemo/SubgridDemo.vue
@@ -9,8 +9,7 @@
 </template>
 
 <script setup>
-// Deliberately uneven content lengths — that's what makes the row
-// alignment visible. Without subgrid, each card sizes its own rows.
+// Deliberately uneven lengths — that's what makes the row alignment visible.
 const cards = [
   {
     title: 'Short',
@@ -40,10 +39,9 @@ const cards = [
 
   .subgrid-card {
     display: grid;
-    /* Each card spans three of the parent grid's rows and adopts them, so
-       title/text/meta line up ACROSS cards regardless of content length.
-       (Subgrid reached Baseline — widely available — in March 2026, so this
-       no longer needs an @supports fallback; baseline-watch confirmed it.) */
+    /* Each card spans and adopts three parent rows, so title/text/meta line up
+       across cards regardless of content length. (Subgrid hit Baseline Mar 2026
+       — no @supports fallback needed.) */
     grid-row: span 3;
     grid-template-rows: subgrid;
     gap: var(--space-2);

--- a/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
+++ b/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="text-wrap-demo">
-    <!-- Two columns of the SAME text so the wrapping difference is
-         visible side by side. The width is deliberately narrow to force
-         ragged line breaks. -->
+    <!-- The SAME text twice so the wrapping difference shows side by side; narrow on purpose. -->
     <figure class="text-wrap-col">
       <figcaption class="text-wrap-label">Default wrapping</figcaption>
       <h5 class="text-wrap-heading">{{ heading }}</h5>
@@ -30,9 +28,8 @@ const body =
 <style scoped lang="scss">
 @layer components {
   .text-wrap-demo {
-    /* Two columns when there's room, stacked when not — no media query.
-       The columns are capped (not 1fr) so the headings stay narrow enough to
-       wrap on wide screens, where the balance/pretty difference is visible. */
+    /* Capped columns (not 1fr) so headings stay narrow enough to wrap on wide
+       screens, where the balance/pretty difference shows. No media query. */
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 18rem));
     justify-content: start;
@@ -63,8 +60,7 @@ const body =
     font-size: var(--text-lg);
     line-height: var(--leading-tight);
 
-    /* balance evens out line lengths across a short block (headings,
-       captions) — best kept to a few lines, which is its sweet spot. */
+    /* balance evens line lengths across a short block (headings) — its sweet spot. */
     &--balance {
       text-wrap: balance;
     }
@@ -74,8 +70,7 @@ const body =
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
 
-    /* pretty targets the LAST line, preventing orphans — cheap enough to
-       use on body copy where balance would be too costly. */
+    /* pretty targets the last line (orphans) — cheap enough for body copy. */
     &--pretty {
       text-wrap: pretty;
     }

--- a/src/showcases/demos/ThemePickerDemo/ThemePickerDemo.vue
+++ b/src/showcases/demos/ThemePickerDemo/ThemePickerDemo.vue
@@ -61,9 +61,8 @@
         </div>
       </div>
 
-      <!-- Live preview. Only --pick-* and --bypass are set inline; the clamp
-           math and --seed-accent live in CSS, so the theme really is derived
-           in the cascade, not in JS. -->
+      <!-- Live preview: only --pick-* / --bypass are set inline; the clamp math
+           and --seed-accent live in CSS, so the theme is derived in the cascade. -->
       <article
         class="surface theme-picker-preview"
         :style="{ '--pick-h': pickH, '--pick-l': pickL, '--bypass': bypass ? 1 : 0 }"
@@ -99,16 +98,14 @@
 import { computed, ref } from 'vue'
 
 import AppButton from '../../../components/AppButton/AppButton.vue'
-// The contrast maths lives in a sibling module so it can be unit-tested; this
-// component just feeds it the picked values (see themePickerMath.test.ts).
+// Contrast maths lives in a sibling module so it's unit-testable (themePickerMath.test.ts).
 import { assessPick } from './themePickerMath'
 
 const pickH = ref(265)
 const pickL = ref(60) // starts inside the dead zone, so the clamp visibly acts
 const bypass = ref(false)
 
-// Accents mirror the .theme-* CVD presets in theming.css (the picker varies
-// only the accent, so the surface stays the default here).
+// Accents mirror the .theme-* CVD presets in theming.css.
 const presets = [
   { name: 'Cobalt', h: 255, l: 48 },
   { name: 'Teal', h: 195, l: 45 },
@@ -124,9 +121,8 @@ const report = computed(() =>
   assessPick({ h: pickH.value, l: pickL.value, bypass: bypass.value }),
 )
 
-// Detect the second safety net so the read-out can be honest about what THIS
-// browser paints: with contrast-color() the rendered label is best-of-black/
-// white; without it, the plain fallback flip is all there is.
+// Detect the second safety net so the read-out is honest about what THIS
+// browser paints (with contrast-color() vs the plain fallback flip).
 const supportsContrastColor =
   typeof CSS !== 'undefined' && CSS.supports('color', 'contrast-color(red)')
 
@@ -258,16 +254,12 @@ const note = computed(() => {
     }
   }
 
-  /* The live preview surface. We set ONLY the picked inputs inline; everything
-     below is the cascade doing the work:
-       1. raw lightness from the slider (0–1),
-       2. a step (no JS) that's 1 when the accent is on the dark side,
-       3. snap a mid-range pick to the nearest safe extreme — dark accents cap
-          at DARK_MAX (white label safe), light accents floor at LIGHT_MIN
-          (black label safe); the muddy middle is squeezed out,
-       4. bypass blends back to the raw value to expose the unsafe pick.
-     Overriding --seed-accent here (components layer) beats theming.css's
-     default (themes layer), and the engine's derivations pick it up. */
+  /* Live preview surface. Only the picked inputs are inline; the cascade does
+     the rest: raw L from the slider → a no-JS step (1 when the accent is dark)
+     → snap a mid pick to the nearest safe extreme (dark caps at DARK_MAX, light
+     floors at LIGHT_MIN; the muddy middle is squeezed out) → bypass blends back
+     to raw to expose the unsafe pick. Overriding --seed-accent here (components
+     layer) beats theming.css (themes layer). */
   .theme-picker-preview {
     --raw-l: calc(var(--pick-l) / 100);
     /* A big multiplier turns the sign of (0.62 − L) into a 0/1 step. */

--- a/src/showcases/demos/ThemePickerDemo/themePickerMath.ts
+++ b/src/showcases/demos/ThemePickerDemo/themePickerMath.ts
@@ -1,12 +1,9 @@
 /**
  * themePickerMath — the colour math behind ThemePickerDemo's contrast read-out.
- *
- * Extracted from the component so it can be unit-tested in isolation: it backs
- * the demo's core promise — that the lightness clamp keeps the button label at
- * WCAG AA for any hue — and that guarantee deserves a test, not just a comment.
- *
- * The clamp itself runs in CSS (see .theme-picker-preview); this mirrors the same maths in
- * JS purely to compute an honest contrast read-out for the figure.
+ * Extracted so it can be unit-tested in isolation (it backs the demo's promise
+ * that the lightness clamp keeps the label at WCAG AA for any hue). The clamp
+ * itself runs in CSS (.theme-picker-preview); this mirrors it in JS only to
+ * compute an honest read-out.
  */
 
 // Fixed chroma keeps the demo focused on the lightness↔contrast relationship

--- a/src/showcases/demos/ZoomCompareDemo/ZoomCompareDemo.vue
+++ b/src/showcases/demos/ZoomCompareDemo/ZoomCompareDemo.vue
@@ -7,8 +7,7 @@
       Pick a magnification and watch the block <em>below</em> each card.
     </p>
 
-    <!-- Pure-CSS control: the checked radio drives a custom property via :has(),
-         no JavaScript. -->
+    <!-- Pure-CSS: the checked radio drives a custom property via :has(). -->
     <fieldset class="zoom-compare-controls">
       <legend class="zoom-compare-legend">Magnify the card</legend>
       <label class="zoom-compare-opt">

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -1,31 +1,18 @@
 /**
- * Showcase registry — single source of truth for the CSS showcases section.
+ * Showcase registry — single source of truth for the CSS showcases section;
+ * App.vue renders this list grouped by status.
  *
- * To add a showcase:
- *   1. Build the demo in its own folder under ./demos/ — XDemo/XDemo.vue,
- *      keeping it small and focused on ONE feature (wrap new syntax in
- *      @supports with a usable fallback). Add at least one portable excerpt
- *      beside it (XDemo/XDemo.snippet.html / .css / .js) for "Show the code".
- *   2. Add an entry here, importing the component and snippet(s). App.vue
- *      renders everything from this list, grouped by status.
+ * To add one: build a small demo under ./demos/ (one feature, new syntax behind
+ * @supports with a fallback) plus a portable *.snippet.* excerpt, then add an
+ * entry here.
  *
- * status:
- *   'stable'   — interoperable in current Chrome, Firefox, and Safari
- *                (Baseline / completed Interop focus areas). May be used
- *                in the foundation itself.
- *   'emerging' — an active Interop focus area or feature with partial
- *                support. Demo only; always progressive enhancement.
+ * status: 'stable' = interoperable now (Baseline / done Interop areas), may be
+ * used in the foundation itself; 'emerging' = active Interop area / partial
+ * support, demo only, always progressive enhancement.
+ * supports = a CSS.supports() condition so ShowcaseFrame can tell visitors
+ * whether they see the feature or the fallback ('' when none applies).
  *
- * supports — a CSS.supports() condition so ShowcaseFrame can tell
- *   visitors whether they see the feature or the fallback. Leave '' when
- *   there is no demo yet or no clean supports check.
- *
- * Support policy for this repo: current browser versions only (roughly
- * the last two years). No fallbacks for anything older.
- *
- * Sources for status decisions:
- *   - https://wpt.fyi/interop-2026 (Interop dashboard)
- *   - https://web-platform-dx.github.io/web-features-explorer/ (Baseline)
+ * Sources: https://wpt.fyi/interop-2026, https://web-platform-dx.github.io/web-features-explorer/
  */
 
 import ContainerCardDemo from './demos/ContainerCardDemo/ContainerCardDemo.vue'
@@ -54,8 +41,7 @@ import DialogPolishDemo from './demos/DialogPolishDemo/DialogPolishDemo.vue'
 import ViewTransitionDemo from './demos/ViewTransitionDemo/ViewTransitionDemo.vue'
 import type { Component } from 'vue'
 
-// Portable code excerpts for the "Show the code" panels, authored as sibling
-// files next to each demo and imported raw (see the snippet fields below).
+// Portable "Show the code" excerpts, imported raw from each demo's sibling files.
 import containerSnippetHtml from './demos/ContainerCardDemo/ContainerCardDemo.snippet.html?raw'
 import containerSnippetCss from './demos/ContainerCardDemo/ContainerCardDemo.snippet.css?raw'
 import hasSnippetHtml from './demos/HasSelectorDemo/HasSelectorDemo.snippet.html?raw'
@@ -101,14 +87,9 @@ export interface Showcase {
   summary: string
   links?: { label: string; href: string }[]
   component: Component
-  /** Extra props forwarded to the demo component, if any. */
   props?: Record<string, unknown>
-  /**
-   * Portable, hand-distilled code excerpts for the "Show the code" panel.
-   * Authored as sibling `*.snippet.html` / `*.snippet.css` files next to the
-   * demo and imported raw, so they live beside the source they teach but stay
-   * free of this repo's tokens, mixins, and @layer plumbing — copy-paste ready.
-   */
+  /** Portable excerpts for the "Show the code" panel — free of this repo's
+      tokens/mixins/@layer plumbing, so they stay copy-paste ready. */
   snippetHtml?: string
   snippetCss?: string
   /** Only for genuine JS-API features (Custom Highlight API, View Transitions). */
@@ -116,9 +97,7 @@ export interface Showcase {
 }
 
 export const showcases: Showcase[] = [
-  /* ---------------------------------------------------------------------
-     Stable — interoperable everywhere, fair game for the foundation
-  --------------------------------------------------------------------- */
+  /* Stable — interoperable everywhere, fair game for the foundation. */
   {
     id: 'container-queries',
     title: 'Container queries',
@@ -257,9 +236,7 @@ export const showcases: Showcase[] = [
     snippetHtml: popoverSnippetHtml,
   },
 
-  /* ---------------------------------------------------------------------
-     Emerging — Interop 2026 focus areas, demos only, behind @supports
-  --------------------------------------------------------------------- */
+  /* Emerging — Interop 2026 focus areas; demos only, behind @supports. */
   {
     id: 'anchor-positioning',
     title: 'Anchor positioning',

--- a/src/styleguide/styleguide.scss
+++ b/src/styleguide/styleguide.scss
@@ -1,6 +1,5 @@
-/* Layout for the living style-guide page. In the components layer so it follows
-   the project's "no unlayered CSS" rule and still loses to user-preference
-   layers. Library mixins are injected via Vite's additionalData. */
+/* Layout for the living style-guide page. In the components layer (the project's
+   "no unlayered CSS" rule); mixins come from Vite's additionalData. */
 @layer components {
   .guide {
     max-inline-size: 60rem;
@@ -270,7 +269,6 @@
     }
   }
 
-  /* Honour the user's request to reduce motion. */
   @include reduced-motion {
     .motion-swatch {
       transition: none;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,8 +1,5 @@
 /* =============================================================================
-   base.css
-
-   Bare-element defaults: typography, document colors, link styling,
-   and minimum interactive target sizes.
+   base.css — bare-element defaults: typography, colours, links, target sizes.
 ============================================================================= */
 
 @layer base {
@@ -40,13 +37,9 @@
     font-size: 0.9em;
   }
 
-  /* ---------------------------------------------------------------------------
-     Minimum target sizes — applied as BASE styles, not gated behind
-     pointer detection. Small targets hurt mouse users with motor
-     impairments too, not just touch users.
-     WCAG 2.5.8 (AA) requires 24×24px; the touch-primary() mixin can
-     raise this toward the 44px best practice on coarse pointers.
-  --------------------------------------------------------------------------- */
+  /* Minimum target sizes — base styles, not gated on pointer type: small
+     targets hurt motor-impaired mouse users too. WCAG 2.5.8 (AA) wants 24×24px;
+     the touch-primary() mixin raises this toward 44px on coarse pointers. */
   button,
   [role="button"],
   select,
@@ -55,10 +48,8 @@
     min-block-size: 24px;
   }
 
-  /* ---------------------------------------------------------------------------
-     Fragment navigation — keep targets clear of sticky headers, and only
-     scroll smoothly for users who haven't asked for reduced motion.
-  --------------------------------------------------------------------------- */
+  /* Fragment navigation — keep targets clear of sticky headers; smooth scroll
+     only when motion is allowed. */
   :target {
     scroll-margin-block-start: var(--space-16);
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,10 +1,7 @@
 /* =============================================================================
-   index.css
-
-   Single entry point for the global styles — import this once in main.js.
-   layers.css must come first so the layer order is established before
-   any rules land in those layers; after that, order is informational
-   only (the cascade is governed by the layers, not source order).
+   index.css — single entry point for global styles (import once in main.js).
+   layers.css must come first to establish the layer order; after that, import
+   order is informational (the cascade is governed by layers, not source order).
 ============================================================================= */
 
 @import './layers.css';

--- a/src/styles/layers.css
+++ b/src/styles/layers.css
@@ -1,9 +1,5 @@
 /* =============================================================================
-   layers.css
-
-   Declares the @layer stack for the entire project.
-   Import this file FIRST — before any other CSS.
-
+   layers.css — the @layer stack. Import FIRST, before any other CSS.
    Layer order = cascade priority (last declared = highest priority).
 
    ⚠ THE ONE RULE THAT MAKES THIS WORK:

--- a/src/styles/preferences.css
+++ b/src/styles/preferences.css
@@ -1,25 +1,16 @@
 /* =============================================================================
-   preferences.css
+   preferences.css — global user-preference overrides.
 
-   Global user preference overrides.
-   Lives in the `preferences` layer — the highest priority layer.
-   These rules cannot be overridden by component or layout styles,
-   PROVIDED all other CSS is layered too (see layers.css).
-
-   This file handles global defaults. Component-level preference
-   overrides belong in the component's own file using the SCSS mixins.
+   Lives in the highest-priority `preferences` layer (see layers.css), so these
+   defaults can't be overridden by component or layout styles. Component-level
+   preference overrides belong in the component's own file via the SCSS mixins.
 ============================================================================= */
 
 @layer preferences {
 
-  /* ---------------------------------------------------------------------------
-     Reduced motion
-     Provides a global safety net. The 0.01ms duration (rather than `none`)
-     keeps animationend/transitionend events firing, so JS that waits on
-     them doesn't break. Individual components should still handle their
-     own animations via the reduced-motion() SCSS mixin when a simplified
-     alternative (rather than removal) is the better experience.
-  --------------------------------------------------------------------------- */
+  /* Reduced motion — global safety net. 0.01ms (not `none`) keeps
+     animationend/transitionend firing, so JS waiting on them doesn't break.
+     Components needing a simplified (not removed) animation use the mixin. */
   @media (prefers-reduced-motion: reduce) {
     *,
     *::before,
@@ -39,15 +30,9 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     High contrast
-     Strengthen borders and remove decorative shadows that lose meaning
-     when contrast is elevated.
-
-     Border color uses CanvasText (the system text color) rather than a
-     hardcoded value, so it stays visible in BOTH light and dark schemes —
-     a hardcoded #000 would vanish against a dark background.
-  --------------------------------------------------------------------------- */
+  /* High contrast — strengthen borders, drop decorative shadows. Border uses
+     CanvasText (system text colour) so it stays visible in light AND dark; a
+     hardcoded #000 would vanish on a dark background. */
   @media (prefers-contrast: more) {
     :root {
       --color-border:      CanvasText;
@@ -63,19 +48,15 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     Forced colors (Windows High Contrast Mode)
-     Restore meaning that is lost when the browser overrides colors.
-     Use CSS system color keywords — never hardcode values here.
-  --------------------------------------------------------------------------- */
+  /* Forced colors (Windows High Contrast) — the browser overrides colours, so
+     restore meaning with system colour keywords; never hardcode values here. */
   @media (forced-colors: active) {
-    /* Ensure focus rings are always visible */
     *:focus-visible {
       outline: 3px solid ButtonText;
       outline-offset: var(--focus-ring-offset);
     }
 
-    /* Restore borders on elements that use background-only differentiation */
+    /* Restore borders where differentiation was background-only. */
     button,
     [role="button"],
     input,
@@ -86,18 +67,12 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     Focus visible — global base
-     Never remove outlines. Style them here consistently.
-     WCAG 2.2 SC 2.4.11/2.4.13 require focus indicators to meet minimum
-     size and contrast — a 3px solid ring with offset comfortably passes.
-
-     Note: no border-radius here. Outlines follow the element's own
-     border-radius in modern browsers; setting it on :focus-visible would
-     visibly change the element's shape while focused.
-  --------------------------------------------------------------------------- */
+  /* Focus visible — global base. WCAG 2.2 SC 2.4.11/2.4.13 need focus
+     indicators of adequate size + contrast; a 3px ring with offset passes.
+     No border-radius here: outlines already follow the element's own radius,
+     and setting it would change the element's shape while focused. */
   *:focus {
-    outline: none; /* Remove default — replaced by :focus-visible below */
+    outline: none; /* replaced by :focus-visible below */
   }
 
   *:focus-visible {

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,8 +1,6 @@
 /* =============================================================================
-   reset.css
-
-   Minimal modern reset — lives in the lowest-priority `reset` layer,
-   so anything anywhere else overrides it without specificity games.
+   reset.css — minimal modern reset in the lowest-priority `reset` layer, so
+   anything elsewhere overrides it without specificity games.
 ============================================================================= */
 
 @layer reset {
@@ -17,25 +15,21 @@
     margin: 0;
   }
 
-  /* The universal margin reset above also clobbers the UA `margin: auto`
-     that centers a modal <dialog> — and an open [popover] — in the viewport,
-     dropping them to the top-left. Restore it so both center by default.
-     (Anchored popovers override this with their own margin in a higher
-     layer, so this only affects the unanchored fallback.) */
+  /* The `* { margin: 0 }` above also kills the UA `margin: auto` that centres a
+     modal <dialog> / open [popover], dropping them top-left. Restore it.
+     (Anchored popovers set their own margin in a higher layer.) */
   dialog,
   [popover] {
     margin: auto;
   }
 
   html {
-    /* Prevent iOS Safari inflating text in landscape.
-       Safari only supports the prefixed form. */
+    /* Prevent iOS Safari inflating text in landscape (prefixed form only). */
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
-    /* Never let the page scroll sideways from an over-wide child. `clip` (not
-       `hidden`) so it doesn't become a scroll container — position: sticky
-       descendants keep working relative to the viewport. */
+    /* `clip` (not `hidden`) so an over-wide child can't scroll the page
+       sideways, without becoming a scroll container (sticky keeps working). */
     overflow-x: clip;
   }
 
@@ -70,9 +64,8 @@
     overflow-wrap: break-word;
   }
 
-  /* Strip list styling only where list semantics are explicitly preserved.
-     Safari removes list semantics from screen readers when list-style is
-     none — adding role="list" restores them, so we key off the attribute. */
+  /* Safari drops list semantics from AT when list-style is none; keying off
+     role="list" restores them, so only strip styling where it's present. */
   ul[role="list"],
   ol[role="list"] {
     list-style: none;

--- a/src/styles/scss/_breakpoints.scss
+++ b/src/styles/scss/_breakpoints.scss
@@ -1,27 +1,15 @@
 // =============================================================================
-// _breakpoints.scss
+// _breakpoints.scss — mobile-first breakpoint mixins.
 //
-// Mobile-first breakpoint mixins.
-//
-// Breakpoints are em-based: em media queries respond to the user's default
-// font size setting (not just zoom), so layouts adapt for users who raise
-// their browser's base font size — px media queries don't.
-// 1em = 16px at default settings.
-//
-// Usage:
-//   @include from('md') { ... }
-//   @include between('sm', 'lg') { ... }
-//
-// Mixin order within a selector block:
-//   1. Base styles (no mixin)
-//   2. from() / between()   — layout and size changes, smallest to largest
+// Em-based: em media queries respond to the user's default font size (not just
+// zoom), so layouts adapt when users raise their base size — px queries don't.
+// Use from()/between() smallest to largest, after base styles.
 // =============================================================================
 
 @use 'sass:map';
 
-// Breakpoint token map.
-// Add or adjust values here — do not hardcode values at call sites.
-// Mirror any change in the --bp-* tokens in tokens.css.
+// Breakpoint token map — edit here, never hardcode at call sites; mirror
+// changes in the --bp-* tokens in tokens.css.
 $breakpoints: (
   'sm':  30em,   // 480px
   'md':  48em,   // 768px
@@ -31,19 +19,7 @@ $breakpoints: (
 ) !default;
 
 
-// from($key)
-// Applies styles from the given breakpoint upward.
-//
-// @param {String} $key - A key from $breakpoints
-//
-// Example:
-//   .card {
-//     padding: var(--space-4);
-//
-//     @include from('md') {
-//       padding: var(--space-8);
-//     }
-//   }
+// from($key) — styles from the given breakpoint upward.
 
 @mixin from($key) {
   $value: map.get($breakpoints, $key);
@@ -58,24 +34,9 @@ $breakpoints: (
 }
 
 
-// between($lower, $upper)
-// Applies styles between two breakpoints (inclusive lower, exclusive upper).
-//
-// Uses media query range syntax — `width < $max` is genuinely exclusive,
-// avoiding the dead zone at fractional viewport widths that the old
-// `max-width: $max - 1px` approach left at certain zoom levels.
-//
-// @param {String} $lower - Lower bound key from $breakpoints
-// @param {String} $upper - Upper bound key from $breakpoints
-//
-// Example:
-//   .sidebar {
-//     display: none;
-//
-//     @include between('md', 'lg') {
-//       display: block;
-//     }
-//   }
+// between($lower, $upper) — inclusive lower, exclusive upper. Range syntax
+// (`width < $max`) is genuinely exclusive, avoiding the fractional-width dead
+// zone the old `max-width: $max - 1px` left at some zoom levels.
 
 @mixin between($lower, $upper) {
   $min: map.get($breakpoints, $lower);

--- a/src/styles/scss/_containers.scss
+++ b/src/styles/scss/_containers.scss
@@ -1,34 +1,20 @@
 // =============================================================================
-// _containers.scss
+// _containers.scss — container-query mixins, the component-level counterpart
+// to _breakpoints.
 //
-// Container query mixins — the component-level counterpart to _breakpoints.
+// Prefer these over from()/between() whenever a component should respond to the
+// space it gets, not the viewport. Em-based like the breakpoints (em resolves
+// against the container's font size — same a11y rationale, per-component).
 //
-// Prefer these over from()/between() whenever a component should respond to
-// the space it actually gets, not the viewport. Combined with intrinsic
-// sizing patterns (auto-fit/minmax grids, flex-wrap), most layouts need no
-// viewport media queries at all; reserve from()/between() for true
-// page-level composition (shells, navigation).
-//
-// Sizes are em-based, like the breakpoints: in a container query, em
-// resolves against the container's font size, so component layouts adapt
-// when users raise their base font size — same a11y rationale as the
-// viewport breakpoints, applied per-component.
-//
-// The element being queried must establish a container first:
-//   .sidebar { container-type: inline-size; }          // anonymous
-//   .sidebar { container: sidebar / inline-size; }     // named
-//
-// Usage:
-//   @include cq-from('sm') { ... }                 // nearest container
-//   @include cq-from('md', 'sidebar') { ... }      // named container
-//   @include cq-between('xs', 'md') { ... }
+// The queried element must establish a container first:
+//   .sidebar { container-type: inline-size; }        // anonymous
+//   .sidebar { container: sidebar / inline-size; }   // named
 // =============================================================================
 
 @use 'sass:map';
 
-// Container size token map.
-// Deliberately separate from $breakpoints — containers are component-scale,
-// so the steps start smaller and stop earlier than viewport breakpoints.
+// Container size token map — deliberately separate from $breakpoints;
+// component-scale, so steps start smaller and stop earlier.
 $container-sizes: (
   'xs': 16em,   // 256px — icon-and-label territory
   'sm': 24em,   // 384px — single column card
@@ -37,11 +23,7 @@ $container-sizes: (
 ) !default;
 
 
-// cq-from($key, $name: null)
-// Applies styles when the (optionally named) container is at least $key wide.
-//
-// @param {String} $key  - A key from $container-sizes
-// @param {String} $name - Optional container-name to query
+// cq-from($key, $name: null) — when the (optionally named) container is at least $key wide.
 
 @mixin cq-from($key, $name: null) {
   $value: map.get($container-sizes, $key);
@@ -63,13 +45,8 @@ $container-sizes: (
 }
 
 
-// cq-between($lower, $upper, $name: null)
-// Applies styles between two container sizes (inclusive lower, exclusive
-// upper) — same range semantics as between().
-//
-// @param {String} $lower - Lower bound key from $container-sizes
-// @param {String} $upper - Upper bound key from $container-sizes
-// @param {String} $name  - Optional container-name to query
+// cq-between($lower, $upper, $name: null) — between two container sizes
+// (inclusive lower, exclusive upper); same range semantics as between().
 
 @mixin cq-between($lower, $upper, $name: null) {
   $min: map.get($container-sizes, $lower);

--- a/src/styles/scss/_interaction.scss
+++ b/src/styles/scss/_interaction.scss
@@ -1,43 +1,15 @@
 // =============================================================================
-// _interaction.scss
+// _interaction.scss — pointer / hover capability mixins.
 //
-// Mixins for pointer and hover capability detection.
-//
-// These mixins should enhance experiences — never use them to gate features.
-// A user may switch between input modes mid-session (e.g. plugging in a mouse).
-//
-// Target sizes: do NOT rely on touch-primary() to make targets big enough.
-// Small targets also hurt mouse users with motor impairments. base.css
-// applies the WCAG 2.5.8 (AA) 24px minimum to all interactive elements;
-// use touch-primary() only to raise that toward the 44px best practice
-// (WCAG 2.5.5, AAA) on coarse pointers.
-//
-// Usage:
-//   @include can-hover { ... }
-//   @include touch-primary { ... }
-//
-// Mixin order within a selector block:
-//   1. Base styles (no mixin)
-//   2. from() / between()
-//   3. can-hover()       — hover and fine-pointer enhancements
-//   4. touch-primary()   — coarse-pointer / touch target adjustments
+// Enhance, never gate: a user may switch input modes mid-session. And don't
+// rely on touch-primary() for target size — base.css already applies the WCAG
+// 2.5.8 (AA) 24px minimum to all interactive elements; touch-primary() only
+// raises that toward the 44px best practice (WCAG 2.5.5, AAA) on coarse pointers.
+// Order in a block: base → from()/between() → can-hover() → touch-primary().
 // =============================================================================
 
 
-// can-hover()
-// Applies styles only when the primary input device supports hover
-// and has fine pointer precision (e.g. mouse, trackpad).
-//
-// Use for: hover effects, tooltip triggers, reduced padding on interactive elements.
-//
-// Example:
-//   .button {
-//     @include can-hover {
-//       &:hover {
-//         background-color: var(--color-primary-hover);
-//       }
-//     }
-//   }
+// can-hover() — primary input supports hover with fine pointer (mouse/trackpad).
 
 @mixin can-hover {
   @media (hover: hover) and (pointer: fine) {
@@ -46,21 +18,8 @@
 }
 
 
-// touch-primary()
-// Applies styles when the primary input is a coarse pointer (e.g. finger on touchscreen).
-//
-// Use for: enlarging touch targets beyond the 24px base minimum,
-// removing hover-only affordances, increasing spacing between
-// interactive elements.
-//
-// Example:
-//   .nav-item {
-//     padding: var(--space-2) var(--space-4);
-//
-//     @include touch-primary {
-//       padding: var(--space-3) var(--space-4); // toward the 44px best practice
-//     }
-//   }
+// touch-primary() — primary input is a coarse pointer (touch). Enlarge targets
+// beyond the 24px base, drop hover-only affordances, add spacing.
 
 @mixin touch-primary {
   @media (pointer: coarse) {

--- a/src/styles/scss/_mixins.scss
+++ b/src/styles/scss/_mixins.scss
@@ -1,13 +1,6 @@
 // =============================================================================
-// _mixins.scss
-//
-// Barrel file — import this single file in your stylesheets.
-//
-// Import order here mirrors the intended cascade order:
-//   breakpoints → containers → interaction → preferences
-//
-// Usage in your stylesheet:
-//   @use 'path/to/mixins' as *;
+// _mixins.scss — barrel file; @use this one file (`@use '…/mixins' as *`).
+// Forward order mirrors the cascade: breakpoints → containers → interaction → preferences.
 // =============================================================================
 
 @forward 'breakpoints';

--- a/src/styles/scss/_preferences.scss
+++ b/src/styles/scss/_preferences.scss
@@ -1,45 +1,16 @@
 // =============================================================================
-// _preferences.scss
+// _preferences.scss — user-preference / accessibility media-query mixins.
 //
-// Mixins for user preference and accessibility media queries.
-//
-// These always sit at the end of a selector block and must never be
-// overridden by breakpoint or interaction mixins. User preferences win.
-//
-// Usage:
-//   @include reduced-motion { ... }
-//   @include reduced-transparency { ... }
-//   @include high-contrast { ... }
-//   @include forced-colors { ... }
-//   @include dark-mode { ... }
-//   @include light-mode { ... }
-//
-// Mixin order within a selector block:
-//   1. Base styles (no mixin)
-//   2. from() / between()
-//   3. can-hover() / touch-primary()
-//   4. reduced-motion()    ← preferences begin here
-//   5. reduced-transparency()
-//   6. high-contrast()
-//   7. forced-colors()
-//   8. dark-mode() / light-mode()
+// These sit at the end of a selector block; user preferences win, so nothing
+// (breakpoint or interaction mixins) should override them. Order in a block:
+// base → from()/between() → can-hover()/touch-primary() → the preference
+// mixins below (reduced-motion, reduced-transparency, high-contrast,
+// forced-colors, dark-mode/light-mode).
 // =============================================================================
 
 
-// reduced-motion()
-// Applies styles when the user has requested reduced motion in their OS settings.
-//
-// Use for: disabling or simplifying animations and transitions.
-// WCAG 2.1 SC 2.3.3 (AAA) — strongly recommended to support at AA level too.
-//
-// Example:
-//   .spinner {
-//     animation: spin 1s linear infinite;
-//
-//     @include reduced-motion {
-//       animation: none;
-//     }
-//   }
+// reduced-motion() — when the user has requested reduced motion.
+// WCAG 2.1 SC 2.3.3 (AAA); worth supporting at AA too.
 
 @mixin reduced-motion {
   @media (prefers-reduced-motion: reduce) {
@@ -48,25 +19,9 @@
 }
 
 
-// reduced-transparency()
-// Applies styles when the user has requested reduced transparency in their
-// OS settings (e.g. "Reduce transparency" on macOS/iOS).
-//
-// Use for: replacing translucent/blurred surfaces (glassmorphism, frosted
-// headers) with opaque backgrounds. Translucency can make text hard to
-// read for low-vision users depending on what scrolls underneath.
-// Progressive enhancement — unsupported browsers simply keep the base style.
-//
-// Example:
-//   .header {
-//     background-color: rgb(255 255 255 / 0.7);
-//     backdrop-filter: blur(8px);
-//
-//     @include reduced-transparency {
-//       background-color: var(--color-surface);
-//       backdrop-filter: none;
-//     }
-//   }
+// reduced-transparency() — swap translucent/blurred surfaces for opaque ones.
+// Translucency can hurt readability for low-vision users. Progressive
+// enhancement: unsupported browsers keep the base style.
 
 @mixin reduced-transparency {
   @media (prefers-reduced-transparency: reduce) {
@@ -75,20 +30,8 @@
 }
 
 
-// high-contrast()
-// Applies styles when the user has requested more contrast in their OS settings.
-//
-// Use for: increasing border visibility, removing low-contrast decorative elements,
-// ensuring text meets elevated contrast ratios.
-//
-// Example:
-//   .card {
-//     border: 1px solid transparent;
-//
-//     @include high-contrast {
-//       border-color: currentColor;
-//     }
-//   }
+// high-contrast() — when the user has requested more contrast (strengthen
+// borders, drop low-contrast decoration).
 
 @mixin high-contrast {
   @media (prefers-contrast: more) {
@@ -97,22 +40,9 @@
 }
 
 
-// forced-colors()
-// Applies styles in Windows High Contrast Mode (now called Forced Colors Mode).
-// The browser replaces most colors with system palette values.
-//
-// Use for: restoring meaning lost when colors are replaced — e.g. adding borders
-// to elements that rely solely on background color for differentiation.
-// Overlooked but important for WCAG compliance on Windows.
-//
-// Example:
-//   .badge {
-//     background-color: var(--color-success);
-//
-//     @include forced-colors {
-//       outline: 2px solid ButtonText; // restore visible boundary
-//     }
-//   }
+// forced-colors() — Windows High Contrast / Forced Colors Mode, where the
+// browser replaces colours with system values. Restore meaning lost when
+// colour alone carried it (e.g. borders on background-only differentiation).
 
 @mixin forced-colors {
   @media (forced-colors: active) {
@@ -121,21 +51,8 @@
 }
 
 
-// dark-mode()
-// Applies styles when the user prefers a dark color scheme.
-//
-// Note: if your theming is handled entirely via CSS custom properties
-// and a [data-theme] attribute, you may not need this mixin at the
-// component level. Use it for cases the token system doesn't cover.
-//
-// Example:
-//   .logo {
-//     filter: none;
-//
-//     @include dark-mode {
-//       filter: invert(1);
-//     }
-//   }
+// dark-mode() — prefers-color-scheme: dark. Often unnecessary at the component
+// level (the token system handles theming); use for cases it doesn't cover.
 
 @mixin dark-mode {
   @media (prefers-color-scheme: dark) {
@@ -144,9 +61,7 @@
 }
 
 
-// light-mode()
-// Applies styles when the user prefers a light color scheme.
-// Less commonly needed but included for symmetry.
+// light-mode() — prefers-color-scheme: light. Included for symmetry.
 
 @mixin light-mode {
   @media (prefers-color-scheme: light) {

--- a/src/styles/theming.css
+++ b/src/styles/theming.css
@@ -1,36 +1,16 @@
 /* =============================================================================
-   theming.css
+   theming.css — seed-driven, contrast-safe theming.
 
-   Seed-driven, contrast-safe theming engine.
+   A theme is two seeds (--seed-surface, --seed-accent); the whole --color-*
+   palette every component reads is derived from them below, so adding a theme
+   is data (the .theme-* presets), not code.
 
-   A theme is just TWO seed colors:
-     --seed-surface   the base background
-     --seed-accent    the brand / primary color
+   Contrast-safe by construction: text flips to black/white against its
+   background via the seed's OKLCH lightness; greys mix toward the text colour,
+   so they gain contrast in the same direction for light and dark themes alike.
 
-   From those, the ENTIRE working palette (the same --color-* tokens that
-   every component already consumes) is DERIVED once, below. So:
-     - Adding a theme is data, not code — see the .theme-* presets at the
-       bottom: two values each.
-     - Any subtree with `.surface` re-themes automatically; components
-       inside need zero changes because they read the same token names.
-
-   Why this is contrast-safe by construction:
-     - Text colors are flipped to black/white against their background using
-       the OKLCH lightness of the seed (relative color syntax), so text is
-       always on the high-contrast side. contrast-color() refines this where
-       supported.
-     - Greys (surface steps, borders, muted text) are MIXED toward the text
-       color, so they gain contrast in the same direction the text does —
-       light themes and dark themes both work from one set of rules.
-
-   Modern CSS used: relative color syntax (oklch(from …)), color-mix(),
-   contrast-color() (progressive enhancement), cascade @layer.
-
-   NOTE: the guarantee currently assumes seeds in sensible lightness ranges
-   (a mid-lightness accent can't reach 4.5:1 with either black or white
-   text). A future user-facing picker (#11 stretch) would clamp seeds into
-   safe ranges. Container style queries are reserved for the colour-vision
-   themes, which add NON-colour cues (underlines, patterns) to descendants.
+   Caveat: assumes seeds in sensible lightness ranges — a mid-lightness accent
+   can't reach 4.5:1 with either black or white text.
 ============================================================================= */
 
 @layer themes {
@@ -40,9 +20,8 @@
     --seed-surface: oklch(99% 0.004 255deg);
     --seed-accent:  oklch(52% 0.16 260deg);
 
-    /* Text: black on light surfaces, white on dark ones. The clamp(…,
-       (threshold - l) * infinity, …) trick resolves the lightness to 0 or
-       1 with no JS and no media query. */
+    /* Text: black on light surfaces, white on dark. clamp(0, (0.62 - l) *
+       infinity, 1) resolves the seed's lightness to 0 or 1 — no JS, no query. */
     --color-text:
       oklch(from var(--seed-surface) clamp(0, (0.62 - l) * infinity, 1) 0 0deg);
 
@@ -60,18 +39,15 @@
     --color-primary-text:
       oklch(from var(--seed-accent) clamp(0, (0.62 - l) * infinity, 1) 0 0deg);
 
-    /* The focus ring tracks the theme accent. */
     --focus-ring-color: var(--seed-accent);
 
-    /* The surface paints itself with the derived palette. */
     background-color: var(--color-bg);
     color: var(--color-text);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     padding: var(--space-4);
 
-    /* Enhancement: let the browser pick the optimal contrasting label,
-       superseding the black/white flip above where supported. */
+    /* Where supported, let the browser pick the optimal label (supersedes the flip above). */
     @supports (color: contrast-color(red)) {
       --color-text:         contrast-color(var(--seed-surface));
       --color-primary-text: contrast-color(var(--seed-accent));
@@ -79,9 +55,7 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     Theme presets — two seeds each. This is the whole cost of a new theme.
-  --------------------------------------------------------------------------- */
+  /* Theme presets — two seeds each. */
   .theme-ocean {
     --seed-surface: oklch(97% 0.025 220deg);
     --seed-accent:  oklch(50% 0.12 230deg);
@@ -98,22 +72,10 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     CVD-robust presets.
-
-     For colour-vision deficiency, what matters is that the accent stays a
-     recognisable colour and that its label keeps a strong LIGHTNESS contrast —
-     because lightness perception is largely intact across protanopia,
-     deuteranopia, and tritanopia, while hue discrimination is not. So these
-     presets do two things:
-       - sit on hues that don't collapse into the neutrals under the common
-         red–green deficiencies, and
-       - keep the accent's lightness well clear of its label's (the engine
-         already guarantees the label is the high-contrast black/white).
-     Hue is never the only signal — pair these with the non-colour cues
-     showcase (status shapes/underlines) for meaning that survives any CVD.
-     Names describe the hue, not a person; anyone can pick them.
-  --------------------------------------------------------------------------- */
+  /* CVD-robust presets: lightness perception survives colour-vision deficiency
+     where hue discrimination doesn't, so these sit on hues that don't collapse
+     into the neutrals and keep the accent's lightness well clear of its label's.
+     Hue is never the only signal (see the non-colour cues showcase). */
   .theme-cobalt {
     --seed-surface: oklch(98% 0.01 255deg);
     --seed-accent:  oklch(48% 0.14 255deg);  /* dark blue → white label */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,28 +1,17 @@
 /* =============================================================================
-   tokens.css
+   tokens.css — design tokens as :root custom properties.
 
-   Design tokens as CSS custom properties.
-   Scoped to :root for global availability.
-
-   Theming uses `color-scheme` + `light-dark()`:
-   - `color-scheme: light dark` follows the OS preference by default AND
-     switches native UI (form controls, scrollbars, canvas) with the theme.
-   - Every color token is declared ONCE with light-dark(light, dark).
-   - Manual theme switching just flips color-scheme via [data-theme] —
-     no token duplication needed.
+   Colour tokens are declared once with light-dark(light, dark); `color-scheme`
+   (below) picks the side, following the OS unless [data-theme] overrides it —
+   no per-theme duplication, and native UI (controls, scrollbars) switches too.
 ============================================================================= */
 
 @layer tokens {
 
   :root {
 
-    /* -------------------------------------------------------------------------
-       Breakpoints
-       Mirror of the $breakpoints map in _breakpoints.scss.
-       Useful for JS that needs to read breakpoint values.
-       Em-based so layouts respond to the user's default font size,
-       not just viewport width. 1em = 16px at default settings.
-    ------------------------------------------------------------------------- */
+    /* Breakpoints — mirror of the $breakpoints map in _breakpoints.scss.
+       Em-based so layouts respond to the user's default font size. */
     --bp-sm:  30em;   /* 480px */
     --bp-md:  48em;   /* 768px */
     --bp-lg:  64em;   /* 1024px */
@@ -30,9 +19,7 @@
     --bp-xxl: 96em;   /* 1536px */
 
 
-    /* -------------------------------------------------------------------------
-       Spacing scale
-    ------------------------------------------------------------------------- */
+    /* Spacing scale */
     --space-1: 0.25rem;
     --space-2: 0.5rem;
     --space-3: 0.75rem;
@@ -47,9 +34,7 @@
     --space-40: 10rem;
 
 
-    /* -------------------------------------------------------------------------
-       Typography
-    ------------------------------------------------------------------------- */
+    /* Typography */
     --font-sans: system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI', sans-serif;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
@@ -61,10 +46,8 @@
     --text-3xl:  1.875rem;
     --text-4xl:  2.25rem;
 
-    /* Fluid display sizes for the hero and section headings. clamp() scales
-       between a mobile floor and a desktop ceiling against viewport width,
-       so headings feel composed at every size with no breakpoints. The
-       rem-based bounds still honor the user's font-size preference. */
+    /* Fluid display sizes: clamp() scales between a mobile floor and desktop
+       ceiling with no breakpoints; rem bounds honour the font-size preference. */
     --text-display:    clamp(2.5rem, 1.6rem + 4.2vw, 4.5rem);
     --text-display-sm: clamp(1.75rem, 1.3rem + 2vw, 2.5rem);
 
@@ -75,9 +58,7 @@
     --tracking-tight: -0.02em;
 
 
-    /* -------------------------------------------------------------------------
-       Color tokens — light-dark(light value, dark value)
-    ------------------------------------------------------------------------- */
+    /* Colour tokens — light-dark(light, dark) */
     --color-bg:           light-dark(#fff, #0f0f0f);
     --color-bg-subtle:    light-dark(#f5f5f5, #1a1a1a);
     --color-surface:      light-dark(#fff, #1e1e1e);
@@ -89,10 +70,9 @@
 
     --color-primary:      light-dark(#2563eb, #3b82f6);
     --color-primary-hover:light-dark(#1d4ed8, #60a5fa);
-    /* The label sits ON --color-primary, so it must contrast the primary itself,
-       not the page. Light-mode primary is a deep blue (white label ≈ 5.2:1); the
-       dark-mode primary is brighter, where white only reaches ~3.7:1 — below AA —
-       so the label flips dark there (≈ 5.1:1). */
+    /* The label sits ON --color-primary, so it must contrast the primary, not
+       the page. The dark-mode primary is brighter (white only ~3.7:1, below
+       AA), so the label flips dark there (≈ 5.1:1). */
     --color-primary-text: light-dark(#fff, #111);
 
     --color-success:      light-dark(#16a34a, #4ade80);
@@ -104,11 +84,8 @@
     --color-accent:       light-dark(#7c3aed, #a78bfa);
 
 
-    /* -------------------------------------------------------------------------
-       Decorative surfaces — for the modern shell (hero, glassy header).
-       The page-glow tints are translucent; preferences.css swaps the glass
-       to an opaque surface under prefers-reduced-transparency.
-    ------------------------------------------------------------------------- */
+    /* Decorative surfaces (hero, glassy header). Translucent; swapped opaque
+       under prefers-reduced-transparency. */
     --gradient-accent: linear-gradient(
       100deg,
       var(--color-primary),
@@ -127,20 +104,14 @@
       );
 
 
-    /* -------------------------------------------------------------------------
-       Focus ring
-       Used globally — keep consistent and never remove outlines entirely.
-    ------------------------------------------------------------------------- */
+    /* Focus ring — used globally; never remove outlines entirely. */
     --focus-ring-width:  3px;
     --focus-ring-offset: 2px;
     --focus-ring-color:  light-dark(#2563eb, #60a5fa);
 
 
-    /* -------------------------------------------------------------------------
-       Motion tokens
-       Reference these in transitions/animations so reduced-motion overrides
-       in preferences.css work from a single source of truth.
-    ------------------------------------------------------------------------- */
+    /* Motion tokens — reference these so preferences.css can override motion
+       from a single source of truth. */
     --duration-fast:    150ms;
     --duration-normal:  250ms;
     --duration-slow:    400ms;
@@ -149,9 +120,7 @@
     --easing-exit:      cubic-bezier(0.4, 0, 1, 1);
 
 
-    /* -------------------------------------------------------------------------
-       Border radius
-    ------------------------------------------------------------------------- */
+    /* Border radius */
     --radius-sm:   0.25rem;
     --radius-md:   0.5rem;
     --radius-lg:   0.75rem;
@@ -159,12 +128,8 @@
     --radius-full: 9999px;
 
 
-    /* -------------------------------------------------------------------------
-       Shadow — layered, soft elevation. Slightly deeper in dark mode so
-       cards still read against a dark canvas.
-    ------------------------------------------------------------------------- */
-    /* light-dark() only wraps the <color> of each layer (it's a color
-       function), never the whole shadow value. */
+    /* Shadow — layered elevation, deeper in dark mode. light-dark() wraps only
+       each layer's <color> (it's a colour function), never the whole value. */
     --shadow-sm: 0 1px 2px light-dark(rgb(15 23 42 / 8%), rgb(0 0 0 / 40%));
     --shadow-md:
       0 2px 4px light-dark(rgb(15 23 42 / 6%), rgb(0 0 0 / 30%)),
@@ -173,19 +138,12 @@
       0 4px 8px light-dark(rgb(15 23 42 / 8%), rgb(0 0 0 / 35%)),
       0 20px 40px -8px light-dark(rgb(15 23 42 / 18%), rgb(0 0 0 / 55%));
 
-    /* -------------------------------------------------------------------------
-       Color scheme — the switch the light-dark() tokens above resolve
-       against. Follows the OS preference unless [data-theme] overrides it.
-    ------------------------------------------------------------------------- */
+    /* The switch the light-dark() tokens resolve against. */
     color-scheme: light dark;
   }
 
 
-  /* ---------------------------------------------------------------------------
-     Manual theme override — set data-theme="light" | "dark" on <html>.
-     Flipping color-scheme is all that's needed: every light-dark() token
-     resolves against it automatically.
-  --------------------------------------------------------------------------- */
+  /* Manual override: [data-theme] just flips color-scheme; every light-dark() token follows. */
   [data-theme="light"] {
     color-scheme: light;
   }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,22 +1,12 @@
 /* =============================================================================
-   utilities.css
-
-   Single-purpose helper classes. The `utilities` layer sits above
-   `components`, so a utility applied to an element reliably wins over
-   that component's own styles — no !important needed.
+   utilities.css — single-purpose helpers. The `utilities` layer sits above
+   `components`, so a utility reliably wins over component styles, no !important.
 ============================================================================= */
 
 @layer utilities {
 
-  /* ---------------------------------------------------------------------------
-     Visually hidden ("sr-only")
-     Hides content visually while keeping it available to screen readers.
-     Use for: labels on icon-only buttons, table captions, live-region text,
-     headings that structure a page for AT but aren't shown.
-
-     The -focusable variant becomes visible when focused — the building
-     block for skip links.
-  --------------------------------------------------------------------------- */
+  /* Visually hidden ("sr-only") — hidden visually, available to screen readers.
+     The -focusable variant becomes visible on focus (skip-link building block). */
   .visually-hidden,
   .visually-hidden-focusable:not(:focus, :focus-within) {
     position: absolute;
@@ -31,15 +21,8 @@
   }
 
 
-  /* ---------------------------------------------------------------------------
-     Skip link
-     Usage:
-       <a class="skip-link visually-hidden-focusable" href="#main">
-         Skip to main content
-       </a>
-     Place as the first focusable element in <body>; give <main> the
-     matching id and tabindex="-1".
-  --------------------------------------------------------------------------- */
+  /* Skip link — first focusable element in <body>, pointing at <main> (which
+     needs the matching id and tabindex="-1"). Pairs with -focusable above. */
   .skip-link {
     position: absolute;
     inset-block-start: var(--space-2);

--- a/src/testing/CoverageMatrix/CoverageMatrix.scss
+++ b/src/testing/CoverageMatrix/CoverageMatrix.scss
@@ -4,8 +4,7 @@
     gap: var(--space-6);
   }
 
-  /* Focusable scroll region: lets the table overflow horizontally on narrow
-     screens while staying reachable and operable by keyboard. */
+  /* Focusable scroll region so the table can overflow horizontally, still keyboard-operable. */
   .coverage-matrix-scroll {
     overflow-x: auto;
 
@@ -76,8 +75,7 @@
     text-align: center;
   }
 
-  /* The glyph carries the verdict together with colour and the visually-hidden
-     label — so it survives greyscale, low vision, and forced-colors. */
+  /* Glyph + visually-hidden label carry the verdict, not colour alone. */
   .coverage-matrix-glyph {
     font-size: var(--text-lg);
     line-height: 1;
@@ -112,8 +110,7 @@
     }
   }
 
-  /* Zebra striping aids row tracking across a wide table; decorative only, so
-     it carries no meaning and drops cleanly under forced-colors. */
+  /* Decorative zebra striping — drops cleanly under forced-colors. */
   tbody tr:nth-child(even) {
     background-color: color-mix(in oklch, var(--color-bg-subtle) 50%, transparent);
 

--- a/src/testing/CoverageMatrix/CoverageMatrix.vue
+++ b/src/testing/CoverageMatrix/CoverageMatrix.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="coverage-matrix">
-    <!-- A real data table: row headers name the defect, column headers name the
-         test method. It's the honest semantic for a matrix — and a screen
-         reader can read any cell as "<issue>, <method>: <verdict>".
-         The wrapper is a focusable scroll region so the table can overflow
-         horizontally on a narrow viewport without trapping keyboard users. -->
+    <!-- A real data table (row/col headers), so a screen reader reads any cell
+         as "<issue>, <method>: <verdict>". The wrapper is a focusable scroll
+         region so it can overflow on narrow viewports without trapping keys. -->
     <div
       class="coverage-matrix-scroll"
       tabindex="0"
@@ -70,8 +68,7 @@ interface Issue {
   human: Verdict
 }
 
-// Ordered so the axe column reads top-to-bottom as a slope: the machine-
-// checkable defects first, the human-only ones last.
+// Ordered so the axe column reads top-to-bottom as a slope (machine-checkable first).
 const issues: Issue[] = [
   { issue: 'Text contrast below 4.5:1', sc: '1.4.3', axe: 'caught', kb: 'missed', human: 'caught' },
   { issue: 'Control has no accessible name', sc: '4.1.2', axe: 'caught', kb: 'missed', human: 'caught' },
@@ -85,8 +82,7 @@ const issues: Issue[] = [
   { issue: 'Status change not announced', sc: '4.1.3', axe: 'missed', kb: 'missed', human: 'caught' },
 ]
 
-// Verdict is never colour alone: a distinct glyph and a screen-reader label
-// carry it too (the same rule the table is teaching).
+// Verdict is never colour alone — a glyph and an SR label carry it too.
 const GLYPHS: Record<Verdict, string> = { caught: '●', partial: '◐', missed: '○' }
 const LABELS: Record<Verdict, string> = { caught: 'Caught', partial: 'Partial', missed: 'Missed' }
 

--- a/src/testing/TestingLayers/TestingLayers.scss
+++ b/src/testing/TestingLayers/TestingLayers.scss
@@ -6,8 +6,7 @@
     padding: 0;
     list-style: none;
 
-    /* Two-up once there's room; the order still reads base → top down each
-       column, which the numbered labels reinforce. */
+    /* Two-up once there's room; numbered labels keep the base→top order clear. */
     @include from('md') {
       grid-template-columns: repeat(2, 1fr);
     }
@@ -52,8 +51,7 @@
     color: var(--color-text-subtle);
   }
 
-  /* A small inline label so the catches/blind-spot split reads at a glance —
-     never colour alone, the word itself carries it. */
+  /* Inline label so the catches/blind-spot split reads without colour alone. */
   .testing-layers-tag {
     display: inline-block;
     margin-inline-end: var(--space-1);

--- a/src/testing/TestingLayers/TestingLayers.vue
+++ b/src/testing/TestingLayers/TestingLayers.vue
@@ -42,9 +42,8 @@ interface Layer {
   here: string[]
 }
 
-// Bottom of the pyramid first: cheap and broad, narrowing to slow-but-
-// irreplaceable. Each layer's `here` points at the real artifact in THIS repo,
-// so the model isn't abstract — it's the test suite you can open and run.
+// Bottom of the pyramid first (cheap and broad → slow but irreplaceable). Each
+// layer's `here` points at the real artifact in this repo.
 const layers: Layer[] = [
   {
     n: '01',


### PR DESCRIPTION
Cut narration/appearance comments and verbose doc blocks (~49%, 1,274→655 lines); kept only non-obvious why — perf rationale, WCAG/a11y notes, browser quirks, and gotchas. Snippet files (user-visible code samples) left untouched.