### PR TITLE
fix: zero automatic grid minimums so iOS WebKit can't inflate sections

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -607,11 +607,13 @@ const toc: TocGroup[] = [
     position: relative;
     isolation: isolate;
     overflow-x: clip;
+    min-inline-size: 0;
   }
 
   .demo {
     display: grid;
     gap: var(--space-6);
+    min-inline-size: 0;
   }
 
   .demo-row {

--- a/src/craft/demos/LightDarkDemo.vue
+++ b/src/craft/demos/LightDarkDemo.vue
@@ -110,6 +110,7 @@
 
   .light-dark-code {
     overflow-x: auto;
+    min-inline-size: 0;
     padding: var(--space-3);
     border-radius: var(--radius-sm);
     background-color: var(--color-bg-subtle);

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -7,6 +7,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    min-inline-size: 0;
   }
 
   /* The spine, centred in the marker column; fades out toward the bottom. */
@@ -33,6 +34,7 @@
     grid-template-columns: var(--space-6) minmax(0, 1fr);
     column-gap: var(--space-4);
     align-items: start;
+    min-inline-size: 0;
   }
 
   .timeline-era-marker {
@@ -66,6 +68,7 @@
   .timeline-era-body {
     display: grid;
     gap: var(--space-4);
+    min-inline-size: 0;
   }
 
   .timeline-era-header {
@@ -95,6 +98,7 @@
   .timeline-era-criteria {
     display: grid;
     gap: var(--space-6);
+    min-inline-size: 0;
   }
 
   .timeline-era-note {

--- a/src/criteria/CriterionFrame/CriterionFrame.scss
+++ b/src/criteria/CriterionFrame/CriterionFrame.scss
@@ -3,6 +3,7 @@
   .criterion {
     display: grid;
     gap: var(--space-4);
+    min-inline-size: 0;
     padding: var(--space-6);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -74,6 +75,7 @@
   }
 
   .criterion-demo {
+    min-inline-size: 0;
     padding: var(--space-4);
     border: 1px dashed var(--color-border);
     border-radius: var(--radius-md);

--- a/src/criteria/demos/ReflowDemo.vue
+++ b/src/criteria/demos/ReflowDemo.vue
@@ -58,6 +58,7 @@ const stats = [
   .reflow-viewport {
     /* Fixed, phone-narrow stage. overflow:auto keeps any overflow local. */
     inline-size: min(100%, 21rem);
+    min-inline-size: 0;
     max-block-size: 15rem;
     overflow: auto;
     border: 1px solid var(--color-border);

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
@@ -3,6 +3,7 @@
   .showcase {
     display: grid;
     gap: var(--space-4);
+    min-inline-size: 0;
     padding: var(--space-6);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -78,6 +79,7 @@
   }
 
   .showcase-demo {
+    min-inline-size: 0;
     padding: var(--space-4);
     border: 1px dashed var(--color-border);
     border-radius: var(--radius-md);

--- a/src/showcases/demos/ScrollSnapDemo/ScrollSnapDemo.vue
+++ b/src/showcases/demos/ScrollSnapDemo/ScrollSnapDemo.vue
@@ -52,6 +52,7 @@ const cards = [
   .snap-track {
     padding: var(--space-2);
     overflow-x: auto;
+    min-inline-size: 0;
     /* The whole point: each card lands on a snap position, never mid-scroll. */
     scroll-snap-type: x mandatory;
     overscroll-behavior-x: contain;

--- a/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
+++ b/src/showcases/demos/ScrollStateDemo/ScrollStateDemo.vue
@@ -91,6 +91,7 @@ const rows = Array.from({ length: 12 }, (_, i) => i + 1)
   .scroll-state-track {
     padding: var(--space-2);
     overflow-x: auto;
+    min-inline-size: 0;
     scroll-snap-type: x mandatory;
     border-radius: var(--radius-md);
 

--- a/src/testing/CoverageMatrix/CoverageMatrix.scss
+++ b/src/testing/CoverageMatrix/CoverageMatrix.scss
@@ -7,6 +7,7 @@
   /* Focusable scroll region so the table can overflow horizontally, still keyboard-operable. */
   .coverage-matrix-scroll {
     overflow-x: auto;
+    min-inline-size: 0;
 
     &:focus-visible {
       outline: var(--focus-ring-width) solid var(--focus-ring-color);


### PR DESCRIPTION
iOS ≤26.5 WebKit doesn't collapse scroll containers' min-content inside nested grids, so the Reflow demo's fixed panel inflated the whole standard-pillar column past the viewport; zeroing the automatic minimum at each grid hop (and on every scroller) cuts the propagation. Verified on-device (iPhone 17, 402pt).