### PR TITLE
fix: drop deprecated baseUrl from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "types": ["vite/client"]
   },


### PR DESCRIPTION
## What changed
Removed `baseUrl` from `tsconfig.json` and made the `@/*` path alias relative to the tsconfig file (`./src/*`).

## Why
TypeScript 6.x flags `baseUrl` as deprecated (it stops working in 7.0), which surfaced as an editor error. Since TS 5.x, `paths` entries resolve relative to the tsconfig file, so `baseUrl` is no longer needed — the alias resolves identically.

## Notes for review
`npm run typecheck` (vue-tsc) passes clean with the change.