### PR TITLE
feat: add Defensive CSS demo showcasing layout resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Accessible by default
 
+**Live site: [accessible-by-default.dev](https://accessible-by-default.dev/)**
+
 An accessibility-first styling foundation — SCSS mixins, design tokens, and
 a cascade-layer architecture — demonstrated in a small Vue 3 playground.
 (Repository and package id: `a11y-foundation`.)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -464,10 +464,16 @@ enhancement only, performance is a hard constraint.
 
 **New content blocks (missing "chapters"):**
 
-- **"Defensive CSS" craft block** (Ahmed) — `min-inline-size: 0`,
-  `minmax(0, 1fr)`, min-content traps. Grounded in this repo's own iOS
-  WebKit overflow war (PRs #15–#19); ties to WCAG 1.4.10 Reflow: robust
-  layouts *are* accessible layouts.
+- **"Defensive CSS" craft block** ✅ Done (July 2026) — craft section
+  "Layouts that expect the worst" (`DefensiveCssDemo`), reframed per Thomas
+  as mockup-vs-reality: two frames, identical CSS — tidy placeholder copy
+  vs. a production deploy URL. A pure-CSS `:has()` toggle removes the
+  `min-inline-size: 0` + scroller guards; the mockup keeps looking flawless
+  (why the bug ships) while reality gets sliced at the frame edge. Ties to
+  WCAG 1.4.10; the iOS QA story is a single low-key parenthetical, not the
+  hook. (Footnotes: the first draft's scrolling `<pre>` lacked `tabindex`
+  and the site's own axe e2e failed the build; the demo scaffolding also
+  needed its own guards at two grid hops to contain its broken state.)
 - **Loading states & `aria-busy`** (Marcy) — skeleton loaders that stay
   honest to the accessibility tree: `aria-busy`, role description, when a
   live region is the wrong tool. A static `:has(:checked)` toggle keeps it

--- a/src/App.vue
+++ b/src/App.vue
@@ -279,6 +279,26 @@
             <AppButton variant="secondary">Secondary action</AppButton>
           </div>
         </section>
+
+        <section class="demo" aria-labelledby="craft-defensive">
+          <h3 id="craft-defensive">Layouts that expect the worst</h3>
+          <p>
+            Defensive CSS is the habit of assuming real content will be longer,
+            wider, and weirder than the mockup. Designs are composed with tidy
+            placeholder copy; CSS has to survive user names, tokens, and URLs.
+            The classic trap: a grid item's automatic minimum size is its
+            <em>min-content</em> size, not zero — the first unbreakable string
+            forces its column wider than the container and pushes the layout
+            past the viewport, a
+            <a href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html">WCAG
+            1.4.10 Reflow</a> failure that low-vision users at high zoom hit
+            first. The guard is boring and load-bearing:
+            <code>min-inline-size: 0</code> at every grid hop, plus a scroll or
+            wrap strategy for content that can't break. (This codebase learned
+            it the hard way during QA, courtesy of an iOS WebKit quirk.)
+          </p>
+          <DefensiveCssDemo />
+        </section>
       </section>
 
       <section id="showcase" class="pillar scrollspy-region" aria-labelledby="showcase-title">
@@ -434,6 +454,7 @@ import CriteriaTimeline from './criteria/CriteriaTimeline/CriteriaTimeline.vue'
 import ConformanceShift from './criteria/ConformanceShift/ConformanceShift.vue'
 import LegalMap from './criteria/LegalMap/LegalMap.vue'
 import LightDarkDemo from './craft/demos/LightDarkDemo.vue'
+import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'
 import { heroIcons } from './icons/heroIcons'
@@ -501,6 +522,7 @@ const toc: TocGroup[] = [
       { id: 'craft-dialog', label: 'Native dialog, zero trapping code' },
       { id: 'craft-motion', label: 'Motion that bows out on request' },
       { id: 'craft-targets', label: 'Targets for touch & forced colors' },
+      { id: 'craft-defensive', label: 'Layouts that expect the worst' },
     ],
   },
   {

--- a/src/craft/demos/DefensiveCssDemo.vue
+++ b/src/craft/demos/DefensiveCssDemo.vue
@@ -1,0 +1,208 @@
+<template>
+  <div class="defensive-demo">
+    <p class="defensive-caption">
+      Two phone-narrow frames, one layout, the same CSS. The left card holds
+      the tidy placeholder copy designs are composed with; the right one holds
+      production content — a deploy URL that can't wrap. Two guards keep it in
+      check: <code>min-inline-size: 0</code> on the grid column and a scroller
+      on the line itself.
+    </p>
+
+    <label class="defensive-toggle">
+      <input type="checkbox" class="defensive-toggle-input" />
+      <span>Remove the guards</span>
+    </label>
+
+    <div class="defensive-frames">
+      <figure class="defensive-frame">
+        <figcaption class="defensive-frame-label">The mockup</figcaption>
+        <div class="defensive-stage">
+          <article class="defensive-card">
+            <span class="defensive-avatar" aria-hidden="true"></span>
+            <div class="defensive-content">
+              <p class="defensive-title">Deploy finished</p>
+              <pre class="defensive-code">v2.4.1 · live</pre>
+              <p class="defensive-note">Everything fits nicely.</p>
+            </div>
+          </article>
+        </div>
+      </figure>
+
+      <figure class="defensive-frame">
+        <figcaption class="defensive-frame-label">Reality</figcaption>
+        <div class="defensive-stage">
+          <article class="defensive-card">
+            <span class="defensive-avatar" aria-hidden="true"></span>
+            <div class="defensive-content">
+              <p class="defensive-title">Deploy finished</p>
+              <!-- tabindex keeps the scrolling line keyboard-reachable (guards on = it scrolls). -->
+              <pre class="defensive-code" tabindex="0">https://accessible-by-default.dev/deploys/2026-07-02/a1b2c3d4e5f6a7b8c9d0</pre>
+              <p class="defensive-note">Production is live. The build took 42 seconds.</p>
+            </div>
+          </article>
+        </div>
+      </figure>
+    </div>
+
+    <p class="defensive-status" role="status">
+      <span class="defensive-status-fixed">
+        Guards on — both frames contain their content; the URL scrolls inside
+        its card.
+      </span>
+      <span class="defensive-status-broken">
+        ⚠ Guards off — the mockup still looks flawless, but the real content
+        forces its column wider than the frame and gets cut off. A review done
+        with placeholder copy would never catch it.
+      </span>
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@layer components {
+  .defensive-demo {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .defensive-caption,
+  .defensive-status {
+    max-inline-size: 60ch;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .defensive-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    inline-size: fit-content;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .defensive-frames {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+    gap: var(--space-4);
+  }
+
+  .defensive-frame {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+    /* The scaffolding practises what the demo preaches: without this the
+       broken card would stretch the frame instead of being clipped by it. */
+    min-inline-size: 0;
+  }
+
+  .defensive-frame-label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-subtle);
+  }
+
+  /* The "viewport": clip, so escaping content gets sliced exactly like a
+     real phone edge. */
+  .defensive-stage {
+    /* "At every grid hop" — the stage is one too (child of the frame grid). */
+    min-inline-size: 0;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    overflow: clip;
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .defensive-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .defensive-avatar {
+    inline-size: 2.5rem;
+    block-size: 2.5rem;
+    border-radius: var(--radius-full);
+    background: var(--gradient-accent);
+
+    @include forced-colors {
+      background: CanvasText;
+    }
+  }
+
+  /* Guard #1: without this, the column's minimum is its min-content size —
+     the full nowrap URL — and the whole grid lays out wider than the stage. */
+  .defensive-content {
+    display: grid;
+    gap: var(--space-2);
+    min-inline-size: 0;
+  }
+
+  .defensive-title {
+    font-weight: 600;
+  }
+
+  /* Guard #2: the unbreakable line gets a local scroll strategy. */
+  .defensive-code {
+    min-inline-size: 0;
+    padding: var(--space-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+    font-size: var(--text-sm);
+    white-space: nowrap;
+    overflow-x: auto;
+
+    &:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: 2px;
+    }
+  }
+
+  .defensive-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  /* Break it: back to the naive version most layouts start as — no minimum
+     overrides anywhere, no scroll strategy on the unbreakable line. The
+     mockup frame gets the same broken CSS and keeps looking perfect: short
+     content never trips the min-content floor. That's the lesson. */
+  .defensive-demo:has(.defensive-toggle-input:checked) {
+    .defensive-content {
+      min-inline-size: auto;
+    }
+
+    .defensive-code {
+      min-inline-size: auto;
+      overflow-x: visible;
+    }
+  }
+
+  /* Status copy swaps with the toggle; role="status" announces the change. */
+  .defensive-status-broken {
+    display: none;
+  }
+
+  .defensive-demo:has(.defensive-toggle-input:checked) {
+    .defensive-status-fixed {
+      display: none;
+    }
+
+    .defensive-status-broken {
+      display: inline;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
**Defensive CSS craft block**
Adds a new craft section, "Layouts that expect the worst", demonstrating the min-content overflow trap and its guards.

The demo (DefensiveCssDemo.vue): two phone-narrow frames with identical CSS — one holding tidy placeholder copy ("the mockup"), one holding a production deploy URL ("reality"). A pure-CSS :has() toggle removes the min-inline-size: 0 + scroller guards. The point lands side by side: the mockup keeps looking flawless while reality gets sliced at the frame edge — which is exactly why the bug ships past reviews done with placeholder content. Ties to WCAG 1.4.10 Reflow.

Also: README now links the live site.

Verified: lint, typecheck, build, and all 18 e2e tests (incl. the axe sweep) pass. The demo's own scaffolding needed min-inline-size: 0 at two grid hops to contain its broken state — it practices what it preaches.