### PR TITLE
feat: add loading state demo with accessibility considerations and aria-busy support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -484,10 +484,15 @@ enhancement only, performance is a hard constraint.
   hook. (Footnotes: the first draft's scrolling `<pre>` lacked `tabindex`
   and the site's own axe e2e failed the build; the demo scaffolding also
   needed its own guards at two grid hops to contain its broken state.)
-- **Loading states & `aria-busy`** (Marcy) — skeleton loaders that stay
-  honest to the accessibility tree: `aria-busy`, role description, when a
-  live region is the wrong tool. A static `:has(:checked)` toggle keeps it
-  JS-free. Possible CoverageMatrix row: "loading state never announced".
+- **Loading states & `aria-busy`** ✅ Done (July 2026) — craft section
+  "Loading states the accessibility tree can see" (`LoadingStateDemo`): two
+  frames side by side — a visual-only skeleton (AT finds an empty region)
+  vs. one with `aria-busy="true"` + a visually-hidden "Loading recent
+  activity…" line; per-frame read-outs say what AT perceives in each state.
+  A Vue toggle simulates the fetch lifecycle (the teaching is HTML/ARIA);
+  shimmer is decorative and static under reduced motion. The prose carries
+  Marcy's live-region caveat (fast loads announce after the fact). Still
+  open: a CoverageMatrix row "loading state never announced".
 - **"Performance is accessibility" prose block** in The proof (Marcy's
   thesis) — compositor-only animation → vestibular safety, main-thread
   health → screen-reader responsiveness, keystroke-level performance as a

--- a/src/App.vue
+++ b/src/App.vue
@@ -299,6 +299,26 @@
           </p>
           <DefensiveCssDemo />
         </section>
+
+        <section class="demo" aria-labelledby="craft-loading">
+          <h3 id="craft-loading">Loading states the accessibility tree can see</h3>
+          <p>
+            Skeleton screens are a perceived-performance trick for the eyes:
+            grey shapes promise that content is on its way. But placeholders
+            are semantic-free <code>div</code>s — a screen reader finds an
+            empty region with no hint that anything is happening. The craft
+            move costs two attributes: <code>aria-busy="true"</code> marks the
+            region as loading (and asks assistive tech to hold announcements
+            until it settles), and one visually-hidden line says what's
+            coming. A live region is usually the <em>wrong</em> tool here — on
+            a fast connection the "loading" announcement lands after the
+            content it was warning about. And size placeholders to the content
+            they stand in for: a skeleton that shifts the page when real
+            content lands trades one jank for another — that shift is what
+            CLS (Cumulative Layout Shift) measures.
+          </p>
+          <LoadingStateDemo />
+        </section>
       </section>
 
       <section id="showcase" class="pillar scrollspy-region" aria-labelledby="showcase-title">
@@ -455,6 +475,7 @@ import ConformanceShift from './criteria/ConformanceShift/ConformanceShift.vue'
 import LegalMap from './criteria/LegalMap/LegalMap.vue'
 import LightDarkDemo from './craft/demos/LightDarkDemo.vue'
 import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
+import LoadingStateDemo from './craft/demos/LoadingStateDemo.vue'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'
 import { heroIcons } from './icons/heroIcons'
@@ -523,6 +544,7 @@ const toc: TocGroup[] = [
       { id: 'craft-motion', label: 'Motion that bows out on request' },
       { id: 'craft-targets', label: 'Targets for touch & forced colors' },
       { id: 'craft-defensive', label: 'Layouts that expect the worst' },
+      { id: 'craft-loading', label: 'Loading states AT can see' },
     ],
   },
   {

--- a/src/craft/demos/LoadingStateDemo.vue
+++ b/src/craft/demos/LoadingStateDemo.vue
@@ -1,0 +1,225 @@
+<template>
+  <div class="loading-demo">
+    <label class="loading-toggle">
+      <input v-model="loading" type="checkbox" />
+      <span>Show the loading state</span>
+    </label>
+
+    <div class="loading-frames">
+      <figure class="loading-frame">
+        <figcaption class="loading-frame-label">Visual-only — the trap</figcaption>
+        <div class="loading-card">
+          <template v-if="loading">
+            <div v-for="n in 2" :key="n" class="loading-row">
+              <span class="loading-shape loading-shape-avatar"></span>
+              <span class="loading-lines">
+                <span class="loading-shape loading-shape-line"></span>
+                <span class="loading-shape loading-shape-line is-short"></span>
+              </span>
+            </div>
+          </template>
+          <template v-else>
+            <div v-for="item in feed" :key="item.name" class="loading-row">
+              <span class="loading-avatar" aria-hidden="true"></span>
+              <span class="loading-lines">
+                <span class="loading-name">{{ item.name }}</span>
+                <span class="loading-action">{{ item.action }}</span>
+              </span>
+            </div>
+          </template>
+        </div>
+        <p class="loading-readout">
+          {{ loading
+            ? 'A screen reader finds: an empty region. Nothing says it’s busy.'
+            : 'Loaded — fine now, but the wait was invisible.' }}
+        </p>
+      </figure>
+
+      <figure class="loading-frame">
+        <figcaption class="loading-frame-label">Announced</figcaption>
+        <div class="loading-card" :aria-busy="loading || undefined">
+          <template v-if="loading">
+            <span class="visually-hidden">Loading recent activity…</span>
+            <div class="loading-skeleton-group" aria-hidden="true">
+              <div v-for="n in 2" :key="n" class="loading-row">
+                <span class="loading-shape loading-shape-avatar"></span>
+                <span class="loading-lines">
+                  <span class="loading-shape loading-shape-line"></span>
+                  <span class="loading-shape loading-shape-line is-short"></span>
+                </span>
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <div v-for="item in feed" :key="item.name" class="loading-row">
+              <span class="loading-avatar" aria-hidden="true"></span>
+              <span class="loading-lines">
+                <span class="loading-name">{{ item.name }}</span>
+                <span class="loading-action">{{ item.action }}</span>
+              </span>
+            </div>
+          </template>
+        </div>
+        <p class="loading-readout">
+          {{ loading
+            ? 'A screen reader finds: aria-busy="true" and “Loading recent activity…”'
+            : 'aria-busy is gone — the content is simply there.' }}
+        </p>
+      </figure>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const loading = ref(true)
+const feed = [
+  { name: 'Maya', action: 'merged “defensive-css” into main' },
+  { name: 'Ben', action: 'starred the repository' },
+]
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .loading-demo {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .loading-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    inline-size: fit-content;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .loading-frames {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+    gap: var(--space-4);
+  }
+
+  .loading-frame {
+    display: grid;
+    gap: var(--space-2);
+    align-content: start;
+    margin: 0;
+    min-inline-size: 0;
+  }
+
+  .loading-frame-label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-subtle);
+  }
+
+  .loading-card {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .loading-row {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-3);
+    align-items: center;
+  }
+
+  .loading-lines {
+    display: grid;
+    gap: var(--space-1);
+    min-inline-size: 0;
+  }
+
+  .loading-avatar {
+    inline-size: 2rem;
+    block-size: 2rem;
+    border-radius: var(--radius-full);
+    background: var(--gradient-accent);
+
+    @include forced-colors {
+      background: CanvasText;
+    }
+  }
+
+  .loading-name {
+    font-weight: 600;
+    font-size: var(--text-sm);
+  }
+
+  .loading-action {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  /* Skeleton shapes: decorative shimmer, static under reduced motion. */
+  .loading-shape {
+    border-radius: var(--radius-sm);
+    background: linear-gradient(
+      100deg,
+      var(--color-bg-subtle) 40%,
+      var(--color-border) 50%,
+      var(--color-bg-subtle) 60%
+    );
+    background-size: 200% 100%;
+    animation: loading-shimmer 1.4s linear infinite;
+
+    @include reduced-motion {
+      animation: none;
+    }
+
+    @include forced-colors {
+      border: 1px solid GrayText;
+      background: Canvas;
+    }
+  }
+
+  .loading-shape-avatar {
+    inline-size: 2rem;
+    block-size: 2rem;
+    border-radius: var(--radius-full);
+  }
+
+  /* Placeholder lines occupy the same line box as the text they stand in
+     for (same font-size, 1lh tall) — so nothing shifts when content lands. */
+  .loading-shape-line {
+    block-size: 1lh;
+    font-size: var(--text-sm);
+    inline-size: 70%;
+
+    &.is-short {
+      inline-size: 45%;
+    }
+  }
+
+  /* The aria-hidden wrapper must not swallow the card's row gap. */
+  .loading-skeleton-group {
+    display: contents;
+  }
+
+  @keyframes loading-shimmer {
+    to {
+      background-position: -200% 0;
+    }
+  }
+
+  .loading-readout {
+    /* Reserve two lines so the state swap can't shift the page — the demo
+       practises the stability it preaches. */
+    min-block-size: 2lh;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>


### PR DESCRIPTION
**Loading states the accessibility tree can see**
Adds a new craft section teaching honest skeleton loaders, from Marcy Sutton Todd's accessibility × performance material.

The demo
Two identical skeleton feeds side by side, with a toggle simulating the fetch lifecycle:

Visual-only (the trap): shimmering placeholder shapes with no semantics — a screen reader finds an empty region with no hint anything is happening.
Announced: the same visuals plus the two-attribute fix — aria-busy="true" on the region and a visually-hidden "Loading recent activity…" line. Skeletons themselves are aria-hidden; when loaded, aria-busy disappears entirely.
Per-frame read-outs describe what assistive tech perceives in each state. The prose carries the key caveat: a live region is usually the wrong tool for loading — on fast connections the announcement lands after the content it was warning about.

Zero layout shift, by construction
Skeletons match the loaded content's geometry, so toggling states moves nothing (verified: 0px shift for both cards and the whole document):

Placeholder lines use the text's own type scale with block-size: 1lh — the lh unit is the line box they stand in for.
The aria-hidden wrapper uses display: contents so it can't swallow the card's grid gap.
The state read-outs reserve min-block-size: 2lh so their own rewrapping can't shift the page.
The section prose ties this to CLS — a skeleton that shifts the page when content lands trades one jank for another.

Details
Shimmer is decorative and static under reduced motion.
Toggle state is Vue (simulating the network); the teaching is pure HTML/ARIA.
New sidebar entry under The Craft.
Verified: lint, typecheck, 35 unit tests, build, all 18 e2e tests (axe clean in Chromium/Firefox/WebKit); ARIA state transitions and zero-shift measured in the live DOM.