### PR TITLE
feat: redesign WCAG timeline with ghost years and foundation strata

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -719,11 +719,15 @@ const toc: TocGroup[] = [
 
   .pillar {
     display: grid;
-    gap: var(--space-12);
+    gap: var(--space-16);
     scroll-margin-block-start: var(--space-16);
     position: relative;
     isolation: isolate;
     min-inline-size: 0;
+
+    @include from('md') {
+      gap: var(--space-24);
+    }
   }
 
   .demo {

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -1,68 +1,73 @@
 /* Library mixins are injected via Vite's additionalData, so no @use here. */
 @layer components {
   .timeline {
-    position: relative;
+    container-type: inline-size;
+    overflow: clip visible;
     display: grid;
-    gap: var(--space-12);
+    gap: var(--space-16);
     margin: 0;
     padding: 0;
     list-style: none;
     min-inline-size: 0;
   }
 
-  /* The spine, centred in the marker column; fades out toward the bottom. */
-  .timeline::before {
-    content: '';
-    position: absolute;
-    inset-block: var(--space-2);
-    inset-inline-start: calc(var(--space-6) / 2);
-    inline-size: 2px;
-    margin-inline-start: -1px;
-    background: linear-gradient(
-      to bottom,
-      var(--color-border) 78%,
-      transparent
-    );
-
-    @include high-contrast {
-      background: currentcolor;
-    }
-  }
-
   .timeline-era {
-    display: grid;
-    grid-template-columns: var(--space-6) minmax(0, 1fr);
-    column-gap: var(--space-4);
-    align-items: start;
+    --timeline-ghost-size: clamp(5.5rem, 24cqi, 9rem);
+
+    position: relative;
+    /* Keeps the z-index: -1 ghost above the page background but below era content. */
+    isolation: isolate;
     min-inline-size: 0;
   }
 
-  .timeline-era-marker {
-    position: relative;
-    z-index: 1;
-    justify-self: center;
-    inline-size: var(--space-4);
-    block-size: var(--space-4);
-    margin-block-start: var(--space-1);
-    border: 2px solid var(--color-bg);
-    border-radius: var(--radius-full);
-    /* Filled = an era with live demos; the accent dot draws the eye. */
-    background: var(--gradient-accent);
-
-    @include high-contrast {
-      border-color: currentcolor;
+  @container (inline-size >= 50rem) {
+    .timeline-era {
+      --timeline-ghost-size: min(7rem, 11cqi);
     }
 
-    @include forced-colors {
-      background: CanvasText;
-      border-color: Canvas;
+    .timeline-era-ghost {
+      position: sticky;
+      inset-block-start: var(--space-16);
+      z-index: -1;
+      block-size: 0;
+    }
+
+    .timeline-era-ghost::before {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+    }
+
+    .timeline-era-criteria {
+      margin-inline-end: calc(var(--timeline-ghost-size) * 2.6);
     }
   }
 
-  /* Foundation (2.0) and future (3.0) eras have no demos — hollow marker. */
-  .timeline-era.is-open .timeline-era-marker {
-    background: var(--color-bg);
-    border-color: var(--color-primary);
+  .timeline-era-ghost {
+    display: block;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .timeline-era-ghost::before {
+    content: attr(data-year) / '';
+    display: block;
+    text-align: end;
+    font-family: var(--font-mono);
+    font-size: var(--timeline-ghost-size);
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.04em;
+    color: transparent;
+    -webkit-text-stroke: 1.5px var(--color-border);
+
+    @include high-contrast {
+      content: none;
+    }
+
+    @include forced-colors {
+      content: none;
+    }
   }
 
   .timeline-era-body {
@@ -72,8 +77,46 @@
   }
 
   .timeline-era-header {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+  }
+
+  .timeline-era-strata {
+    display: grid;
+    gap: 3px;
+    flex: none;
+    inline-size: var(--space-6);
+    margin-block-start: var(--space-2);
+  }
+
+  .timeline-strata-layer {
+    block-size: 6px;
+    border-radius: 2px;
+    background: var(--color-primary);
+
+    &:not(:first-child) {
+      background: var(--color-border);
+    }
+
+    @include forced-colors {
+      background: CanvasText;
+    }
+  }
+
+  .timeline-era.is-new-model .timeline-era-strata {
+    margin-inline-start: var(--space-2);
+  }
+
+  .timeline-era.is-new-model .timeline-strata-layer {
+    background: transparent;
+    border: 1.5px dashed var(--color-text-subtle);
+  }
+
+  .timeline-era-heading {
     display: grid;
     gap: var(--space-1);
+    min-inline-size: 0;
   }
 
   .timeline-era-title {
@@ -114,34 +157,75 @@
     }
   }
 
-  /* Scroll-driven (off the main thread) flourishes — the accent spine draws
-     down and markers pop in as their era arrives. Motion- and support-gated. */
+  .timeline-now {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-inline-size: 0;
+
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      border-block-start: 2px solid var(--color-primary);
+    }
+
+    &::after {
+      border-block-start-style: dashed;
+      border-block-start-color: var(--color-border);
+    }
+  }
+
+  .timeline-now-label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-primary);
+  }
+
+  .timeline-now-year {
+    font-family: var(--font-mono);
+    font-weight: 400;
+    text-transform: none;
+    color: var(--color-text-subtle);
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     @supports (animation-timeline: view()) {
-      .timeline::after {
-        content: '';
-        position: absolute;
-        inset-block: var(--space-2);
-        inset-inline-start: calc(var(--space-6) / 2);
-        inline-size: 2px;
-        margin-inline-start: -1px;
-        background: var(--gradient-accent);
-        transform: scaleY(0);
-        transform-origin: top;
-        animation: timeline-fill linear both;
-        animation-timeline: view();
-        /* Spread the fill across most of the pass so it keeps drawing to the
-           last era; the end % is the knob (higher = finishes later). */
-        animation-range: cover 12% cover 96%;
+      .timeline-era {
+        view-timeline: --timeline-era block;
       }
 
-      .timeline-era-marker {
-        animation: marker-pop linear both;
-        animation-timeline: view();
-        animation-range: entry 0% cover 12%;
+      .timeline-era-ghost::before {
+        animation: ghost-drift linear both;
+        animation-timeline: --timeline-era;
+        animation-range: cover 0% cover 100%;
       }
 
-      /* Cards glide in on entry; they live in the child component, so :deep(). */
+      .timeline-strata-layer {
+        animation: layer-pour linear both;
+        animation-timeline: view();
+
+        &:nth-child(1) {
+          animation-range: cover 0% cover 25%;
+        }
+
+        &:nth-child(2) {
+          animation-range: cover 10% cover 35%;
+        }
+
+        &:nth-child(3) {
+          animation-range: cover 20% cover 45%;
+        }
+      }
+
+      .timeline-now-label {
+        animation: layer-pour linear both;
+        animation-timeline: view();
+        animation-range: cover 0% cover 40%;
+      }
+
       /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
       :deep(.criterion) {
         animation: era-slide-in linear both;
@@ -149,16 +233,30 @@
         animation-range: entry 0% entry 65%;
       }
 
-      @keyframes timeline-fill {
-        to {
-          transform: scaleY(1);
+      @keyframes ghost-drift {
+        0% {
+          opacity: 0;
+          translate: 0 2rem;
+        }
+
+        18% {
+          opacity: 1;
+        }
+
+        82% {
+          opacity: 1;
+        }
+
+        100% {
+          opacity: 0;
+          translate: 0 -2rem;
         }
       }
 
-      @keyframes marker-pop {
+      @keyframes layer-pour {
         from {
-          transform: scale(0.4);
-          opacity: 0.3;
+          opacity: 0;
+          translate: 0 -0.4rem;
         }
       }
 

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.vue
@@ -1,45 +1,51 @@
 <template>
-  <!-- <ol>: the era order is chronological and meaningful. Spine/markers are decorative. -->
   <ol class="timeline">
-    <li
-      v-for="era in eras"
-      :key="era.id"
-      class="timeline-era"
-      :class="{ 'is-open': !era.items.length }"
-    >
-      <span class="timeline-era-marker" aria-hidden="true"></span>
-      <div class="timeline-era-body">
-        <header class="timeline-era-header">
-          <h4 class="timeline-era-title">
-            {{ era.label }} <span class="timeline-era-year">{{ era.year }}</span>
-          </h4>
-          <p class="timeline-era-summary">{{ era.summary }}</p>
-        </header>
+    <template v-for="era in eras" :key="era.id">
+      <li class="timeline-era" :class="{ 'is-new-model': era.newModel }">
+        <span class="timeline-era-ghost" :data-year="era.ghost" aria-hidden="true"></span>
+        <div class="timeline-era-body">
+          <header class="timeline-era-header">
+            <span class="timeline-era-strata" aria-hidden="true">
+              <span v-for="n in era.depth" :key="n" class="timeline-strata-layer"></span>
+            </span>
+            <div class="timeline-era-heading">
+              <h4 class="timeline-era-title">
+                {{ era.label }} <span class="timeline-era-year">{{ era.year }}</span>
+              </h4>
+              <p class="timeline-era-summary">{{ era.summary }}</p>
+            </div>
+          </header>
 
-        <div v-if="era.items.length" class="timeline-era-criteria">
-          <CriterionFrame
-            v-for="c in era.items"
-            :key="c.id"
-            :id="c.id"
-            :name="c.name"
-            :level="c.level"
-            :version="c.version"
-            :principle="c.principle"
-            :requirement="c.requirement"
-            :break-label="c.breakLabel"
-            :restore-label="c.restoreLabel"
-            :pass-text="c.passText"
-            :fail-text="c.failText"
-            :links="c.links"
-            :heading-level="5"
-            v-slot="{ broken }"
-          >
-            <component :is="c.component" :broken="broken" />
-          </CriterionFrame>
+          <div v-if="era.items.length" class="timeline-era-criteria">
+            <CriterionFrame
+              v-for="c in era.items"
+              :key="c.id"
+              :id="c.id"
+              :name="c.name"
+              :level="c.level"
+              :version="c.version"
+              :principle="c.principle"
+              :requirement="c.requirement"
+              :break-label="c.breakLabel"
+              :restore-label="c.restoreLabel"
+              :pass-text="c.passText"
+              :fail-text="c.failText"
+              :links="c.links"
+              :heading-level="5"
+              v-slot="{ broken }"
+            >
+              <component :is="c.component" :broken="broken" />
+            </CriterionFrame>
+          </div>
+          <p v-else class="timeline-era-note">{{ era.note }}</p>
         </div>
-        <p v-else class="timeline-era-note">{{ era.note }}</p>
-      </div>
-    </li>
+      </li>
+      <li v-if="era.id === 'wcag22'" class="timeline-now">
+        <p class="timeline-now-label">
+          You are here <span class="timeline-now-year">2026</span>
+        </p>
+      </li>
+    </template>
   </ol>
 </template>
 
@@ -47,11 +53,16 @@
 import CriterionFrame from '../CriterionFrame/CriterionFrame.vue'
 import { criteria, wcagTimeline } from '../registry'
 
-// Group criteria by WCAG version; version-less eras stay empty and show their note.
-const eras = wcagTimeline.map((era) => ({
-  ...era,
-  items: era.version ? criteria.filter((c) => c.version === era.version) : [],
-}))
+const eras = wcagTimeline.map((era, index) => {
+  const newModel = era.id === 'wcag30'
+  return {
+    ...era,
+    items: era.version ? criteria.filter((c) => c.version === era.version) : [],
+    depth: newModel ? 2 : index + 1,
+    newModel,
+    ghost: newModel ? '3.0' : era.year,
+  }
+})
 </script>
 
 <style scoped lang="scss" src="./CriteriaTimeline.scss"></style>


### PR DESCRIPTION
Replaces the timeline spine with an editorial redesign: each era opens with a giant outlined year numeral, and the dot markers become cumulative "strata" glyphs (2.0 = one layer, 2.2 = three; 3.0 is a dashed pour set apart — a new model, not another layer). A "you are here — 2026" divider separates the shipped standard from the draft: solid rule behind, dashed ahead.

The implementation dogfoods the site's own material: per-era named view-timelines (so scroll effects track what's actually on screen), cqi-fluid numerals, content: attr() / '' for CSS-level decorative alt text, and a @container query that switches the numeral between two modes — in-flow chapter number on narrow columns, sticky companion in a reserved rail on wide ones (≥ 50rem, where it stays visible beside the cards instead of behind them). overflow: clip visible guards the inline axis only, letting the last numeral hang into the section gap. All motion is gated behind prefers-reduced-motion + @supports; the watermark is removed under forced-colors and prefers-contrast: more. Block-level section gaps widened site-wide (64px mobile / 96px desktop).

Verified: axe clean ×3 engines, 35 unit + 18 e2e, both container modes at 375/803/1440px, zero horizontal overflow.