### PR TITLE
feat: add :user-valid showcase, light-dark style-query card, coverage row

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,65 +17,71 @@ git history and the PRs, not here.
 
 ---
 
-## Open
+## The plan
 
-### Next up
+Ordered waves, one branch each; work top to bottom.
 
-- **Subgrid card alignment** — only if criteria/showcase cards ever sit side
-  by side; verify the layout before building.
+### Wave 1 — quick wins
 
-### Showcase backlog
-
-- Container query units — `cqi` + `clamp()` ultra-fluid components.
-- Pure-CSS carousel — scroll buttons + `::scroll-marker`, presented WITH the
-  current screen-reader caveats (that honesty is the site's voice).
+- `:user-valid` / `:user-invalid` showcase — stable tier; TextField already
+  uses it.
 - `light-dark()` beyond color — style-query trick for non-color values;
-  could extend LightDarkDemo instead of a new entry.
-- `:user-valid` / `:user-invalid` — stable tier; TextField already uses it.
-- Media state pseudo-classes (`:playing` etc.) — custom player demo.
-- High-contrast light/dark presets — needs the engine's grey mix strengths
-  (border 44% / subtle 62%) promoted to per-theme data (a contrast-boost
-  knob): contrast as data, not duplicate palettes. Complements
-  `prefers-contrast: more` for users without the OS setting.
-
-### Content backlog
-
-- "Performance is accessibility" prose block in The proof — compositor
-  animation → vestibular safety, main-thread health → SR responsiveness,
-  keystroke-level performance as a metric.
-- "Break it with content" craft block — stress-test a real component with a
-  content switcher: designer-perfect copy → long titles → German compound
-  words → Arabic with `dir="rtl"`. The RTL leg proves the logical-properties
-  rigor already in the codebase (`:dir()` styling, no left/right anywhere);
-  the long-content legs show the defensive guards absorbing it. Absorbs the
-  old RTL-block idea; content variants via tiny Vue state (simulated CMS —
-  allowed). Inspired by Shadeed's "Breaking a Layout Intentionally"
-  (Debugging CSS, ch. 5) and his RTL Styling 101.
-- Diagnostic stylesheet ("CSS that audits") for The proof — a small debug
-  stylesheet that outlines a11y smells using modern selectors alone:
-  `img:not([alt])`, `a[target="_blank"]:not(:has(.visually-hidden))`,
-  `button:empty`, unlabeled inputs via `:not(:has(+ label))`. Shown against
-  an intentionally broken sample fragment; teaches that the selector
-  engine itself can be an audit tool.
+  extends LightDarkDemo rather than a new entry.
 - CoverageMatrix row: "loading state never announced" (axe can't see it).
 
-### Infra / nice-to-have
+### Wave 2 — container query units showcase
+
+- `cqi` + `clamp()` ultra-fluid components — formalizes what the timeline's
+  ghost numerals already dogfood.
+
+### Wave 3 — high-contrast presets (+ theming split)
+
+- High-contrast light/dark presets — the engine's grey mix strengths
+  (border 44% / subtle 62%) become per-theme data (a contrast-boost knob):
+  contrast as data, not duplicate palettes. Complements
+  `prefers-contrast: more` for users without the OS setting.
+- While in there: grow `theming.css` into `src/theming/`.
+
+### Wave 4 — "Break it with content" craft block
+
+- Stress-test a real component with a content switcher: designer-perfect
+  copy → long titles → German compound words → Arabic with `dir="rtl"`.
+  The RTL leg proves the logical-properties rigor already in the codebase
+  (`:dir()` styling, no left/right anywhere); the long-content legs show
+  the defensive guards absorbing it. Content variants via tiny Vue state
+  (simulated CMS — allowed). Inspired by Shadeed's "Breaking a Layout
+  Intentionally" (Debugging CSS, ch. 5) and his RTL Styling 101.
+
+### Wave 5 — The proof pillar pass
+
+- Diagnostic stylesheet ("CSS that audits") — a small debug stylesheet that
+  outlines a11y smells using modern selectors alone: `img:not([alt])`,
+  `a[target="_blank"]:not(:has(.visually-hidden))`, `button:empty`,
+  unlabeled inputs via `:not(:has(+ label))`. Shown against an intentionally
+  broken sample fragment; the selector engine as an audit tool.
+- "Performance is accessibility" prose block — compositor animation →
+  vestibular safety, main-thread health → SR responsiveness,
+  keystroke-level performance as a metric.
+
+### Wave 6 — pure-CSS carousel
+
+- Scroll buttons + `::scroll-marker`, presented WITH the current
+  screen-reader caveats (that honesty is the site's voice). Biggest build;
+  emerging tier.
+
+### Wave 7 — infra
 
 - Derive the stable/emerging grouping (and sidebar clusters) from the
   Baseline data instead of the hand-maintained `status` field;
   `baseline-watch` already flags transitions.
-- Grow `theming.css` into a `src/theming/` directory when it next expands.
 
-### Decisions parked with Thomas
+### Conditional / Watchlist
 
-- **CSS naming convention** — the informal house style (root class +
-  role-named descendants, no BEM ceremony) works; write it into GUIDE.md so
-  it's documented intent, not accident.
-- **Long-term reimagining** (“less documentation-like”) — open design
-  question; Thomas brings references, discuss before building.
-
-### Watchlist (too early — revisit)
-
+- Subgrid card alignment — only if criteria/showcase cards ever sit side by
+  side; verify the layout before building.
+- Media state pseudo-classes (`:playing` etc.) — checked July 2026: no
+  Chromium support (Firefox 150 + Safari only, Baseline false per
+  web-features); revisit when Chrome ships.
 - `sibling-index()` / `sibling-count()` — Canary only.
 - `border-shape` — spec in flux; candidate for the anchor-tooltip arrow.
 - Overscroll areas / built-in gestures — early spec discussion.

--- a/scripts/gen-baseline.mjs
+++ b/scripts/gen-baseline.mjs
@@ -25,6 +25,7 @@ const SHOWCASE_FEATURES = {
   'text-wrap': 'text-wrap-balance',
   'scroll-snap': 'scroll-snap',
   popover: 'popover',
+  'user-valid': 'user-pseudos',
   'anchor-positioning': 'anchor-positioning',
   'anchor-tooltip': 'anchor-positioning',
   'contrast-color': 'contrast-color',

--- a/src/craft/demos/LightDarkDemo.vue
+++ b/src/craft/demos/LightDarkDemo.vue
@@ -17,7 +17,7 @@
           <code>light-dark()</code> — follows the toggle
         </h4>
         <div class="light-dark-swatch light-dark-swatch-modern" aria-hidden="true"></div>
-        <pre class="light-dark-code"><code>background-color: light-dark(#e6e6fa, #1a1a2e);</code></pre>
+        <pre class="light-dark-code" tabindex="0"><code>background-color: light-dark(#e6e6fa, #1a1a2e);</code></pre>
         <p class="light-dark-note">
           One line, both values together so they can’t drift — and because it
           resolves against <code>color-scheme</code>, it honours the user’s
@@ -31,7 +31,7 @@
           <code>@media</code> — only hears the OS
         </h4>
         <div class="light-dark-swatch light-dark-swatch-legacy" aria-hidden="true"></div>
-        <pre class="light-dark-code"><code>background-color: #e6e6fa;
+        <pre class="light-dark-code" tabindex="0"><code>background-color: #e6e6fa;
 
 @media (prefers-color-scheme: dark) {
   background-color: #1a1a2e;
@@ -43,6 +43,31 @@
           switcher, that’s not just verbose: it’s wrong.
         </p>
       </article>
+
+      <article class="light-dark-card">
+        <h4 class="light-dark-card-title">
+          Beyond color — the style-query trick
+        </h4>
+        <div class="light-dark-swatch light-dark-swatch-probe" aria-hidden="true"></div>
+        <pre class="light-dark-code" tabindex="0"><code>@property --scheme-probe {
+  syntax: '&lt;color&gt;';
+  inherits: true;
+  initial-value: white;
+}
+
+.card { --scheme-probe: light-dark(white, black); }
+
+@container style(--scheme-probe: black) {
+  .swatch { border-style: dashed; /* any property */ }
+}</code></pre>
+        <p class="light-dark-note">
+          <code>light-dark()</code> only returns colors — but a registered
+          custom property resolves it to one, and a style query can read that
+          answer back and switch <em>any</em> property on it: this swatch
+          changes its border style and glyph per scheme, still zero JS. Flip
+          the header toggle to watch it.
+        </p>
+      </article>
     </div>
   </div>
 </template>
@@ -52,6 +77,12 @@
 </script>
 
 <style scoped lang="scss">
+@property --scheme-probe {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: white;
+}
+
 @layer components {
   .light-dark-demo {
     display: grid;
@@ -70,6 +101,8 @@
   }
 
   .light-dark-card {
+    --scheme-probe: light-dark(white, black);
+
     display: grid;
     gap: var(--space-3);
     align-content: start;
@@ -105,6 +138,28 @@
 
     @include dark-mode {
       background-color: #1a1a2e;
+    }
+  }
+
+  .light-dark-swatch-probe {
+    display: grid;
+    place-items: center;
+    background-color: var(--color-bg-subtle);
+    border-width: 2px;
+    font-size: var(--text-xl);
+
+    &::after {
+      content: '☀' / '';
+    }
+  }
+
+  @container style(--scheme-probe: black) {
+    .light-dark-swatch-probe {
+      border-style: dashed;
+
+      &::after {
+        content: '☾' / '';
+      }
     }
   }
 

--- a/src/showcases/baseline-data.json
+++ b/src/showcases/baseline-data.json
@@ -103,6 +103,19 @@
       "safari": "17"
     }
   },
+  "user-valid": {
+    "feature": "user-pseudos",
+    "name": ":user-valid and :user-invalid",
+    "baseline": "high",
+    "lowDate": "2023-11-02",
+    "highDate": "2026-05-02",
+    "support": {
+      "chrome": "119",
+      "edge": "119",
+      "firefox": "88",
+      "safari": "16.5"
+    }
+  },
   "anchor-positioning": {
     "feature": "anchor-positioning",
     "name": "Anchor positioning",

--- a/src/showcases/demos/UserValidDemo/UserValidDemo.snippet.css
+++ b/src/showcases/demos/UserValidDemo/UserValidDemo.snippet.css
@@ -1,0 +1,16 @@
+/* :invalid fires immediately — an empty required field is
+   "wrong" before the user has done anything at all. */
+.field-eager:invalid {
+  border-color: var(--color-error);
+}
+
+/* :user-invalid waits for real interaction: it only matches
+   after the user has edited or left the field. Same native
+   validation, judged at a humane moment. */
+.field-patient:user-invalid {
+  border-color: var(--color-error);
+}
+
+.field-patient:user-valid {
+  border-color: var(--color-success);
+}

--- a/src/showcases/demos/UserValidDemo/UserValidDemo.vue
+++ b/src/showcases/demos/UserValidDemo/UserValidDemo.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="user-valid-demo">
+    <p class="user-valid-caption">
+      Both fields require an email address and use identical native validation.
+      The difference is manners: <code>:invalid</code> scolds the left field
+      before you've typed a thing, while <code>:user-invalid</code> /
+      <code>:user-valid</code> stay quiet until you've actually been in the
+      right field and left it — then judge what you typed.
+    </p>
+
+    <div class="user-valid-grid">
+      <div class="user-valid-field">
+        <label class="user-valid-label" :for="eagerId"><code>:invalid</code> — eager</label>
+        <input
+          :id="eagerId"
+          class="user-valid-input user-valid-input-eager"
+          type="email"
+          required
+          placeholder="you@example.com"
+        />
+        <p class="user-valid-hint">Flagged from first paint — you haven't done anything yet.</p>
+      </div>
+
+      <div class="user-valid-field">
+        <label class="user-valid-label" :for="patientId"><code>:user-invalid</code> — patient</label>
+        <input
+          :id="patientId"
+          class="user-valid-input user-valid-input-patient"
+          type="email"
+          required
+          placeholder="you@example.com"
+        />
+        <p class="user-valid-hint">Neutral until you visit and leave; then valid turns green, invalid red.</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue'
+
+const eagerId = useId()
+const patientId = useId()
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .user-valid-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .user-valid-caption {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .user-valid-grid {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  }
+
+  .user-valid-field {
+    display: grid;
+    gap: var(--space-2);
+    align-content: start;
+  }
+
+  .user-valid-label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .user-valid-input {
+    padding: var(--space-2) var(--space-3);
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+  }
+
+  .user-valid-input-eager:invalid {
+    border-color: var(--color-error);
+  }
+
+  .user-valid-input-patient:user-invalid {
+    border-color: var(--color-error);
+  }
+
+  .user-valid-input-patient:user-valid {
+    border-color: var(--color-success);
+  }
+
+  .user-valid-hint {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -49,6 +49,8 @@ import containerSnippetHtml from './demos/ContainerCardDemo/ContainerCardDemo.sn
 import containerSnippetCss from './demos/ContainerCardDemo/ContainerCardDemo.snippet.css?raw'
 import hasSnippetHtml from './demos/HasSelectorDemo/HasSelectorDemo.snippet.html?raw'
 import hasSnippetCss from './demos/HasSelectorDemo/HasSelectorDemo.snippet.css?raw'
+import UserValidDemo from './demos/UserValidDemo/UserValidDemo.vue'
+import userValidSnippetCss from './demos/UserValidDemo/UserValidDemo.snippet.css?raw'
 import quantitySnippetHtml from './demos/QuantityQueriesDemo/QuantityQueriesDemo.snippet.html?raw'
 import quantitySnippetCss from './demos/QuantityQueriesDemo/QuantityQueriesDemo.snippet.css?raw'
 import subgridSnippetCss from './demos/SubgridDemo/SubgridDemo.snippet.css?raw'
@@ -283,6 +285,25 @@ export const showcases: Showcase[] = [
     ],
     component: PopoverMenuDemo,
     snippetHtml: popoverSnippetHtml,
+  },
+  {
+    id: 'user-valid',
+    title: ':user-valid / :user-invalid',
+    status: 'stable',
+    supports: 'selector(:user-valid)',
+    summary:
+      'Validation styling with manners — these pseudo-classes match only ' +
+      'after the user has actually interacted with a field, so an empty ' +
+      'required form isn’t flagged red on first paint. Newly Baseline ' +
+      'widely available; the foundation’s own TextField builds on it.',
+    links: [
+      {
+        label: 'MDN: :user-invalid',
+        href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid',
+      },
+    ],
+    component: UserValidDemo,
+    snippetCss: userValidSnippetCss,
   },
 
   /* Emerging — Interop 2026 focus areas; demos only, behind @supports. */

--- a/src/testing/CoverageMatrix/CoverageMatrix.vue
+++ b/src/testing/CoverageMatrix/CoverageMatrix.vue
@@ -80,6 +80,7 @@ const issues: Issue[] = [
   { issue: 'Icon / border contrast (non-text)', sc: '1.4.11', axe: 'missed', kb: 'missed', human: 'caught' },
   { issue: 'Meaning carried by colour alone', sc: '1.4.1', axe: 'missed', kb: 'missed', human: 'caught' },
   { issue: 'Status change not announced', sc: '4.1.3', axe: 'missed', kb: 'missed', human: 'caught' },
+  { issue: 'Loading state never announced', sc: '4.1.3', axe: 'missed', kb: 'missed', human: 'caught' },
 ]
 
 // Verdict is never colour alone — a glyph and an SR label carry it too.


### PR DESCRIPTION
Wave 1 of the roadmap plan: a stable-tier :user-valid/:user-invalid showcase (newly Baseline widely available), a "beyond color" card on the light-dark craft demo (registered-property probe + style query switching non-color values), and a "loading never announced" CoverageMatrix row. Media pseudo-classes checked against web-features and parked (no Chromium support); the GUIDE.md naming item was already documented. Code pres in the light-dark demo gained tabindex="0" after axe flagged them scrollable at the new three-column width.