### PR TITLE
feat: add container query units showcase

### DIFF
--- a/scripts/gen-baseline.mjs
+++ b/scripts/gen-baseline.mjs
@@ -18,6 +18,7 @@ import { features } from 'web-features'
     upstream feature are simply absent — no badge is rendered for them. */
 const SHOWCASE_FEATURES = {
   'container-queries': 'container-queries',
+  'cq-units': 'container-queries',
   'has-selector': 'has',
   'quantity-queries': 'has',
   subgrid: 'subgrid',

--- a/src/showcases/baseline-data.json
+++ b/src/showcases/baseline-data.json
@@ -12,6 +12,19 @@
       "safari": "16"
     }
   },
+  "cq-units": {
+    "feature": "container-queries",
+    "name": "Container queries",
+    "baseline": "high",
+    "lowDate": "2023-02-14",
+    "highDate": "2025-08-14",
+    "support": {
+      "chrome": "105",
+      "edge": "105",
+      "firefox": "110",
+      "safari": "16"
+    }
+  },
   "has-selector": {
     "feature": "has",
     "name": ":has()",

--- a/src/showcases/demos/CqUnitsDemo/CqUnitsDemo.snippet.css
+++ b/src/showcases/demos/CqUnitsDemo/CqUnitsDemo.snippet.css
@@ -1,0 +1,16 @@
+.stage {
+  container-type: inline-size;
+}
+
+/* 1cqi = 1% of the container's inline size. Everything scales in
+   proportion to the component's own space — no breakpoints, no
+   viewport units, no "in-between" states to break. */
+.card {
+  padding: clamp(0.75rem, 6cqi, 2.5rem);
+}
+
+.card-stat {
+  /* rem floor and ceiling: fluid in the middle, but the user's
+     font-size preference always sets the limits. */
+  font-size: clamp(1.75rem, 14cqi, 4.5rem);
+}

--- a/src/showcases/demos/CqUnitsDemo/CqUnitsDemo.vue
+++ b/src/showcases/demos/CqUnitsDemo/CqUnitsDemo.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="cq-units">
+    <label class="cq-units-control">
+      Container width
+      <input v-model="width" type="range" min="30" max="100" step="1" />
+      <span aria-hidden="true">{{ width }}%</span>
+    </label>
+
+    <div class="cq-units-stage" :style="{ inlineSize: `${width}%` }">
+      <article class="cq-units-card">
+        <p class="cq-units-label">Uptime this quarter</p>
+        <p class="cq-units-stat">99.98%</p>
+        <p class="cq-units-note">
+          Every size in here is <code>clamp(rem, cqi, rem)</code> — type,
+          spacing, the swatch. Drag the slider: nothing snaps, it scales.
+        </p>
+      </article>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const width = ref(100)
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .cq-units {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .cq-units-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    font-size: var(--text-sm);
+
+    input {
+      flex: 1;
+      min-inline-size: 8rem;
+    }
+  }
+
+  .cq-units-stage {
+    container-type: inline-size;
+    min-inline-size: min(100%, 12rem);
+  }
+
+  /* No thresholds anywhere: every value scales in proportion to the
+     container, clamped in rem so user font-size settings stay respected. */
+  .cq-units-card {
+    display: grid;
+    gap: clamp(0.25rem, 2cqi, 0.75rem);
+    padding: clamp(0.75rem, 6cqi, 2.5rem);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-subtle);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .cq-units-label {
+    font-size: clamp(0.75rem, 3.5cqi, 1rem);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-subtle);
+  }
+
+  .cq-units-stat {
+    font-size: clamp(1.75rem, 14cqi, 4.5rem);
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    color: var(--color-primary);
+  }
+
+  .cq-units-note {
+    max-inline-size: 40ch;
+    font-size: clamp(0.8rem, 3cqi, 0.95rem);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -49,6 +49,8 @@ import containerSnippetHtml from './demos/ContainerCardDemo/ContainerCardDemo.sn
 import containerSnippetCss from './demos/ContainerCardDemo/ContainerCardDemo.snippet.css?raw'
 import hasSnippetHtml from './demos/HasSelectorDemo/HasSelectorDemo.snippet.html?raw'
 import hasSnippetCss from './demos/HasSelectorDemo/HasSelectorDemo.snippet.css?raw'
+import CqUnitsDemo from './demos/CqUnitsDemo/CqUnitsDemo.vue'
+import cqUnitsSnippetCss from './demos/CqUnitsDemo/CqUnitsDemo.snippet.css?raw'
 import UserValidDemo from './demos/UserValidDemo/UserValidDemo.vue'
 import userValidSnippetCss from './demos/UserValidDemo/UserValidDemo.snippet.css?raw'
 import quantitySnippetHtml from './demos/QuantityQueriesDemo/QuantityQueriesDemo.snippet.html?raw'
@@ -141,6 +143,26 @@ export const showcases: Showcase[] = [
     component: ContainerCardDemo,
     snippetHtml: containerSnippetHtml,
     snippetCss: containerSnippetCss,
+  },
+  {
+    id: 'cq-units',
+    title: 'Container query units',
+    status: 'stable',
+    supports: 'width: 1cqi',
+    summary:
+      'The other half of container queries: cqi units inside clamp() scale ' +
+      'type and spacing in proportion to the component’s own space — no ' +
+      'breakpoints, no broken in-between states, and rem bounds keep the ' +
+      'user’s font-size preference in charge. The timeline’s ghost years ' +
+      'run on this.',
+    links: [
+      {
+        label: 'MDN: container query length units',
+        href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries#container_query_length_units',
+      },
+    ],
+    component: CqUnitsDemo,
+    snippetCss: cqUnitsSnippetCss,
   },
   {
     id: 'has-selector',


### PR DESCRIPTION
Wave 2: stable-tier showcase for container query length units — a fully fluid metric card sized entirely with clamp(rem, cqi, rem), no breakpoints. Complements the container-queries entry (thresholds vs. proportion); rem clamp bounds keep user font-size preferences authoritative. Baseline badge maps to the container-queries feature.