### PR TITLE
feat: add break-it-with-content craft block

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,14 @@ Ordered waves, one branch each; work top to bottom.
   (simulated CMS — allowed). Inspired by Shadeed's "Breaking a Layout
   Intentionally" (Debugging CSS, ch. 5) and his RTL Styling 101.
 
-### Wave 5 — The proof pillar pass
+### Wave 5 — The proof pillar pass (+ responsive-reveal card)
+
+- Extension card on the @starting-style showcase: the trick inside a
+  breakpoint — a hidden panel fades in when its container crosses a width
+  threshold instead of popping (`@starting-style` + `allow-discrete` inside
+  `@container`), slider-driven. Our version adds the guard the viral
+  snippet skips: reduced-motion gating (resize/rotation triggers it).
+  Inspired by @micka_design on X.
 
 - Diagnostic stylesheet ("CSS that audits") — a small debug stylesheet that
   outlines a11y smells using modern selectors alone: `img:not([alt])`,

--- a/src/App.vue
+++ b/src/App.vue
@@ -314,6 +314,23 @@
           <DefensiveCssDemo />
         </section>
 
+        <section class="demo" aria-labelledby="craft-content-stress">
+          <h3 id="craft-content-stress">Break it with content</h3>
+          <p>
+            Layouts don't break in design reviews; they break the day the CMS
+            delivers a title nobody planned for. The habit that catches it
+            early is feeding a component hostile content on purpose: the
+            longest plausible headline, German compound words that refuse to
+            wrap, a right-to-left language. One card survives all four feeds
+            below because the guards were built in — logical properties
+            instead of left and right, <code>min-inline-size: 0</code> where
+            grids meet text, <code>hyphens: auto</code> riding on an honest
+            <code>lang</code> attribute, and a button sized by its label
+            instead of a designer's optimism.
+          </p>
+          <ContentStressDemo />
+        </section>
+
         <section class="demo" aria-labelledby="craft-loading">
           <h3 id="craft-loading">Loading states the accessibility tree can see</h3>
           <p>
@@ -489,6 +506,7 @@ import ConformanceShift from './criteria/ConformanceShift/ConformanceShift.vue'
 import LegalMap from './criteria/LegalMap/LegalMap.vue'
 import LightDarkDemo from './craft/demos/LightDarkDemo.vue'
 import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
+import ContentStressDemo from './craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from './craft/demos/LoadingStateDemo.vue'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'
@@ -559,6 +577,7 @@ const toc: TocGroup[] = [
       { id: 'craft-motion', label: 'Motion that bows out on request' },
       { id: 'craft-targets', label: 'Targets for touch & forced colors' },
       { id: 'craft-defensive', label: 'Layouts that expect the worst' },
+      { id: 'craft-content-stress', label: 'Break it with content' },
       { id: 'craft-loading', label: 'Loading states AT can see' },
     ],
   },

--- a/src/craft/demos/ContentStressDemo.vue
+++ b/src/craft/demos/ContentStressDemo.vue
@@ -1,0 +1,217 @@
+<template>
+  <div class="content-stress-demo">
+    <fieldset class="content-stress-control">
+      <legend class="content-stress-legend">Content source</legend>
+      <label v-for="v in variants" :key="v.id" class="content-stress-option">
+        <input v-model="activeId" type="radio" name="content-stress" :value="v.id" />
+        {{ v.label }}
+      </label>
+    </fieldset>
+
+    <div class="content-stress-stage">
+      <article class="content-stress-card" :dir="active.dir" :lang="active.lang">
+        <div class="content-stress-avatar" aria-hidden="true">{{ active.initials }}</div>
+        <div class="content-stress-body">
+          <p class="content-stress-tag">{{ active.tag }}</p>
+          <h4 class="content-stress-title">{{ active.title }}</h4>
+          <p class="content-stress-byline">{{ active.byline }}</p>
+        </div>
+        <button class="content-stress-action" type="button">{{ active.action }}</button>
+      </article>
+    </div>
+
+    <p class="content-stress-note">{{ active.note }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface Variant {
+  id: string
+  label: string
+  dir: 'ltr' | 'rtl'
+  lang: string
+  initials: string
+  tag: string
+  title: string
+  byline: string
+  action: string
+  note: string
+}
+
+const variants: Variant[] = [
+  {
+    id: 'designed',
+    label: 'As designed',
+    dir: 'ltr',
+    lang: 'en',
+    initials: 'DR',
+    tag: 'Recipe',
+    title: 'Quick weeknight pasta',
+    byline: 'By Dana Reeves · 12 min read',
+    action: 'Save',
+    note: 'The card the designer signed off — short, tidy, and deceptive. Real content never stays this polite.',
+  },
+  {
+    id: 'long',
+    label: 'Long content',
+    dir: 'ltr',
+    lang: 'en',
+    initials: 'AKV',
+    tag: 'Longform investigation',
+    title:
+      'How I learned to stop worrying and love the fact that a CMS will eventually feed every component a title exactly this long',
+    byline: 'By Dr. Alexandra Konstantinopoulos-Vandenberg · 47 min read',
+    action: 'Save for later',
+    note: 'The title wraps, the button grows with its label instead of clipping it, and nothing escapes the card — min-inline-size: 0 on the text column does the quiet work.',
+  },
+  {
+    id: 'german',
+    label: 'German',
+    dir: 'ltr',
+    lang: 'de',
+    initials: 'ML',
+    tag: 'Rezept',
+    title: 'Streichholzschächtelchen und die Donaudampfschifffahrtsgesellschaft: ein Küchenexperiment',
+    byline: 'Von Frau Müller-Lüdenscheidt · 12 Min. Lesezeit',
+    action: 'Speichern',
+    note: 'Compound words are unbreakable by default. hyphens: auto splits them correctly — but only because the card carries lang="de"; the hyphenation dictionary follows the language, not the layout.',
+  },
+  {
+    id: 'arabic',
+    label: 'Arabic (RTL)',
+    dir: 'rtl',
+    lang: 'ar',
+    initials: 'دن',
+    tag: 'وصفة',
+    title: 'معكرونة سريعة لأمسيات الأسبوع المزدحمة',
+    byline: 'بقلم دانا ريفز · ١٢ دقيقة قراءة',
+    action: 'حفظ',
+    note: 'One dir="rtl" and the whole card mirrors — accent bar, avatar, button — because every offset in it is a logical property. And :dir(rtl) removes the title’s letter-spacing: Arabic script joins its letters, so tracking that flatters Latin type would tear it apart.',
+  },
+]
+
+const activeId = ref('designed')
+const active = computed(() => variants.find((v) => v.id === activeId.value) ?? variants[0])
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .content-stress-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .content-stress-control {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    align-items: center;
+    margin: 0;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+  }
+
+  .content-stress-legend {
+    float: inline-start;
+    padding-inline-end: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .content-stress-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+  }
+
+  .content-stress-stage {
+    container-type: inline-size;
+  }
+
+  .content-stress-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: start;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-inline-start: 4px solid var(--color-primary);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-subtle);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .content-stress-avatar {
+    display: grid;
+    place-items: center;
+    inline-size: var(--space-12);
+    block-size: var(--space-12);
+    border-radius: var(--radius-full);
+    background-color: var(--color-primary);
+    color: var(--color-primary-text);
+    font-size: var(--text-sm);
+    font-weight: 700;
+  }
+
+  .content-stress-body {
+    display: grid;
+    gap: var(--space-1);
+    min-inline-size: 0;
+  }
+
+  .content-stress-tag {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text-subtle);
+  }
+
+  .content-stress-title {
+    font-size: var(--text-lg);
+    letter-spacing: 0.01em;
+    text-wrap: balance;
+    hyphens: auto;
+
+    &:dir(rtl) {
+      letter-spacing: 0;
+    }
+  }
+
+  .content-stress-byline {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .content-stress-action {
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+
+    @include can-hover {
+      &:hover {
+        border-color: var(--color-text-subtle);
+      }
+    }
+  }
+
+  .content-stress-note {
+    min-block-size: 3lh;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>


### PR DESCRIPTION
Wave 4: a content stress-test craft block — one card fed four hostile content variants (long titles, German compounds, Arabic RTL) via a simulated-CMS switcher. Demonstrates the i18n guards in the codebase working together: logical properties, :dir(), hyphens: auto + lang, min-inline-size: 0, label-sized buttons. Inspired by Shadeed's "Breaking a Layout Intentionally" (Debugging CSS ch. 5) and RTL Styling 101. Also adds the responsive-reveal card idea to the Wave 5 roadmap entry.