### PR TITLE
Feat/wave 5 proof pillar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -429,6 +429,40 @@
           </p>
           <CoverageMatrix />
         </section>
+
+        <section class="demo" aria-labelledby="testing-audit-css">
+          <h3 id="testing-audit-css">CSS that audits</h3>
+          <p>
+            The selector engine itself can be a testing layer. A handful of
+            modern selectors — <code>:not()</code>, <code>:has()</code>,
+            attribute checks — describe accessibility smells precisely enough
+            to paint them on screen: no build step, no extension, just a
+            stylesheet you drop into DevTools on any page. Flip the toggle and
+            watch four planted defects light up while their healthy twins stay
+            quiet.
+          </p>
+          <AuditStylesheet />
+        </section>
+
+        <section class="demo" aria-labelledby="testing-performance">
+          <h3 id="testing-performance">Performance is accessibility</h3>
+          <p>
+            Performance work usually files under "nice to have." For assistive
+            tech it's load-bearing. A screen reader walks the accessibility
+            tree through the same main thread your JavaScript blocks — every
+            long task is a stretch of silence between a keypress and hearing
+            where you landed. Motion that stutters is harder on vestibular
+            disorders than motion that glides, which is why this site animates
+            only <code>transform</code> and <code>opacity</code>: honoring
+            <code>prefers-reduced-motion</code> is step one, keeping the
+            remaining motion off the main thread is step two. And input
+            latency is felt hardest by the people who type through switch
+            devices or sticky keys — for them, a sluggish keystroke isn't an
+            annoyance but the interface going unresponsive mid-word. Less
+            JavaScript isn't just this site's aesthetic; it's why the
+            assistive-tech experience stays quick.
+          </p>
+        </section>
       </section>
     </main>
     </div>
@@ -509,6 +543,7 @@ import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
 import ContentStressDemo from './craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from './craft/demos/LoadingStateDemo.vue'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
+import AuditStylesheet from './testing/AuditStylesheet/AuditStylesheet.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'
 import { heroIcons } from './icons/heroIcons'
 import { pillarIcons, type PillarIconName } from './icons/pillarIcons'
@@ -614,6 +649,8 @@ const toc: TocGroup[] = [
     sections: [
       { id: 'testing-layers', label: 'A layered job, not a button' },
       { id: 'testing-coverage', label: 'What automation can’t see' },
+      { id: 'testing-audit-css', label: 'CSS that audits' },
+      { id: 'testing-performance', label: 'Performance is accessibility' },
     ],
   },
 ]

--- a/src/criteria/demos/TargetSizeDemo.vue
+++ b/src/criteria/demos/TargetSizeDemo.vue
@@ -15,7 +15,10 @@
         :aria-label="tool.label"
         @click="active[tool.id] = !active[tool.id]"
       >
-        <span aria-hidden="true">{{ tool.glyph }}</span>
+        <span v-if="tool.glyph" class="target-size-glyph" aria-hidden="true">{{ tool.glyph }}</span>
+        <svg v-else class="target-size-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path :d="tool.d" />
+        </svg>
       </button>
     </div>
   </div>
@@ -28,12 +31,27 @@ defineProps({
   broken: { type: Boolean, default: false },
 })
 
-const tools = [
+interface Tool {
+  id: string
+  label: string
+  glyph?: string
+  d?: string
+}
+
+const tools: Tool[] = [
   { id: 'bold', glyph: 'B', label: 'Bold' },
   { id: 'italic', glyph: 'I', label: 'Italic' },
   { id: 'underline', glyph: 'U', label: 'Underline' },
-  { id: 'link', glyph: '🔗', label: 'Insert link' },
-  { id: 'list', glyph: '☰', label: 'Bulleted list' },
+  {
+    id: 'link',
+    label: 'Insert link',
+    d: 'M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71 M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71',
+  },
+  {
+    id: 'list',
+    label: 'Bulleted list',
+    d: 'M4.5 6h.01 M9.5 6H20 M4.5 12h.01 M9.5 12H20 M4.5 18h.01 M9.5 18H20',
+  },
 ]
 
 const active = reactive<Record<string, boolean>>({})
@@ -91,6 +109,20 @@ const active = reactive<Record<string, boolean>>({})
     @include forced-colors {
       border-color: ButtonText;
     }
+  }
+
+  .target-size-glyph {
+    line-height: 1;
+  }
+
+  .target-size-icon {
+    inline-size: 1.1em;
+    block-size: 1.1em;
+    fill: none;
+    stroke: currentcolor;
+    stroke-width: 2.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
   }
 
   /* The regression: drop well under 24px and remove spacing, so targets are

--- a/src/showcases/demos/StartingStyleDemo/StartingStyleDemo.snippet.css
+++ b/src/showcases/demos/StartingStyleDemo/StartingStyleDemo.snippet.css
@@ -17,3 +17,33 @@
     opacity: 0;
   }
 }
+
+/* The same trick inside a breakpoint: crossing it FADES the panel
+   in instead of popping it. */
+.panel {
+  display: none;
+  opacity: 0;
+  transition:
+    opacity 250ms,
+    display 250ms allow-discrete;
+}
+
+@container (inline-size >= 26rem) {
+  .panel {
+    display: grid;
+    opacity: 1;
+
+    @starting-style {
+      opacity: 0;
+    }
+  }
+}
+
+/* Resize and device rotation fire this transition, so gate the
+   MOTION — never the visibility. The panel must still appear for
+   reduced-motion users; it just stops animating. */
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
+}

--- a/src/showcases/demos/StartingStyleDemo/StartingStyleDemo.vue
+++ b/src/showcases/demos/StartingStyleDemo/StartingStyleDemo.vue
@@ -24,6 +24,34 @@
         just <code>@starting-style</code> plus a transition.
       </p>
     </div>
+
+    <p class="starting-style-caption">
+      The same trick composes with breakpoints: put the block inside a
+      container (or media) query and responsive state changes <em>fade</em>
+      instead of popping. The motion tokens still guard it — resizing and
+      device rotation trigger this, so reduced motion collapses it to an
+      instant swap. Narrow the space until the details panel leaves, then
+      widen it again:
+    </p>
+
+    <label class="starting-style-control">
+      Container width
+      <input v-model="stageWidth" type="range" min="40" max="100" step="1" />
+      <span aria-hidden="true">{{ stageWidth }}%</span>
+    </label>
+
+    <div class="starting-style-stage" :style="{ inlineSize: `${stageWidth}%` }">
+      <div class="starting-style-app">
+        <div class="starting-style-main">
+          <p class="starting-style-card-title">Inbox</p>
+          <p class="starting-style-card-text">The content that's always there.</p>
+        </div>
+        <aside class="starting-style-panel">
+          <p class="starting-style-card-title">Details</p>
+          <p class="starting-style-card-text">I fade in when there's room.</p>
+        </aside>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -33,6 +61,7 @@ import { ref } from 'vue'
 import AppButton from '../../../components/AppButton/AppButton.vue'
 
 const open = ref(false)
+const stageWidth = ref(100)
 </script>
 
 <style scoped lang="scss">
@@ -80,6 +109,75 @@ const open = ref(false)
 
     @include high-contrast {
       border-color: currentcolor;
+    }
+  }
+
+  .starting-style-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    justify-self: stretch;
+    font-size: var(--text-sm);
+
+    input {
+      flex: 1;
+      min-inline-size: 8rem;
+    }
+  }
+
+  .starting-style-stage {
+    container-type: inline-size;
+    justify-self: stretch;
+    min-inline-size: min(100%, 14rem);
+  }
+
+  .starting-style-app {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .starting-style-main {
+    flex: 1;
+    min-inline-size: 0;
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+  }
+
+  .starting-style-panel {
+    display: none;
+    inline-size: 40%;
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+    opacity: 0;
+    translate: 0.5rem 0;
+    transition:
+      opacity var(--duration-normal) var(--easing-standard),
+      translate var(--duration-normal) var(--easing-standard),
+      display var(--duration-normal) allow-discrete;
+  }
+
+  @container (inline-size >= 26rem) {
+    .starting-style-panel {
+      display: grid;
+      gap: var(--space-1);
+      align-content: start;
+      opacity: 1;
+      translate: 0 0;
+
+      @starting-style {
+        opacity: 0;
+        translate: 0.5rem 0;
+      }
     }
   }
 

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -513,9 +513,10 @@ export const showcases: Showcase[] = [
     supports: 'transition-behavior: allow-discrete',
     summary:
       'Animate an element in from display:none — entry transitions with no ' +
-      'JS — and out via transition-behavior: allow-discrete. The transitions ' +
-      'use motion tokens, so they respect reduced motion. Interop 2026 focus ' +
-      'area.',
+      'JS — and out via transition-behavior: allow-discrete. Composes with ' +
+      'container queries too: responsive reveals that fade instead of pop. ' +
+      'The transitions use motion tokens, so they respect reduced motion. ' +
+      'Interop 2026 focus area.',
     links: [
       {
         label: 'MDN: @starting-style',

--- a/src/testing/AuditStylesheet/AuditStylesheet.scss
+++ b/src/testing/AuditStylesheet/AuditStylesheet.scss
@@ -1,0 +1,133 @@
+@layer components {
+  .audit-css {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .audit-css-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .audit-css-frame {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-md);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .audit-css-frame-label {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .audit-css-specimen {
+    display: grid;
+    gap: var(--space-4);
+    align-items: start;
+    padding: var(--space-4);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+
+    @include from('sm') {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .audit-css-image {
+    border-radius: var(--radius-sm);
+  }
+
+  .audit-css-field {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .audit-css-field-labeled {
+    display: grid;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .audit-css-input {
+    min-inline-size: 0;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    font-size: var(--text-sm);
+  }
+
+  .audit-css-icon-button {
+    inline-size: var(--space-8);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg);
+  }
+
+  .audit-css-icon-button::before {
+    content: '🔍' / '';
+  }
+
+  .audit-css-line {
+    font-size: var(--text-sm);
+
+    a {
+      color: var(--color-primary);
+    }
+  }
+
+  .audit-css-button {
+    justify-self: start;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    font: inherit;
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  /* The debug stylesheet itself — the same four selectors the <pre> shows,
+     scoped to the specimen and armed by the toggle. */
+  .audit-css:has(.audit-css-toggle-input:checked) .audit-css-specimen {
+    img:not([alt]),
+    button:empty,
+    input:not(label input, [aria-label], [aria-labelledby]),
+    a[target='_blank']:not(:has(.visually-hidden)) {
+      outline: 3px dashed var(--color-error);
+      outline-offset: 2px;
+    }
+  }
+
+  .audit-css-code {
+    overflow-x: auto;
+    min-inline-size: 0;
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+    font-size: var(--text-sm);
+    white-space: pre;
+  }
+
+  .audit-css-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}

--- a/src/testing/AuditStylesheet/AuditStylesheet.vue
+++ b/src/testing/AuditStylesheet/AuditStylesheet.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="audit-css">
+    <label class="audit-css-toggle">
+      <input class="audit-css-toggle-input" type="checkbox" />
+      Apply the debug stylesheet
+    </label>
+
+    <div class="audit-css-frame">
+      <p class="audit-css-frame-label">
+        Specimen — four planted defects, two healthy controls. Behind glass
+        (<code>inert</code> and hidden from assistive tech): even broken
+        examples must never harm a real visitor.
+      </p>
+
+      <div class="audit-css-specimen" inert aria-hidden="true">
+        <img class="audit-css-image" src="/favicon.svg" width="48" height="48" />
+        <img class="audit-css-image" src="/favicon.svg" width="48" height="48" alt="Site logo" />
+        <div class="audit-css-field">
+          <input class="audit-css-input" type="text" placeholder="Search…" />
+          <button class="audit-css-icon-button"></button>
+        </div>
+        <label class="audit-css-field-labeled">
+          Email
+          <input class="audit-css-input" type="email" />
+        </label>
+        <p class="audit-css-line">
+          Prices include VAT — <a href="#audit-noop" target="_blank">see the full terms</a>.
+        </p>
+        <button class="audit-css-button">Save changes</button>
+      </div>
+    </div>
+
+    <pre class="audit-css-code" tabindex="0"><code>img:not([alt]),
+button:empty,
+input:not(label input, [aria-label], [aria-labelledby]),
+a[target="_blank"]:not(:has(.visually-hidden)) {
+  outline: 3px dashed red;
+  outline-offset: 2px;
+}</code></pre>
+
+    <p class="audit-css-note">
+      Four selectors, four catches: the alt-less image, the empty icon
+      button, the label-less search field, and the new-tab link with no
+      warning — while their healthy twins stay untouched. axe would flag the
+      first three; the new-tab hint is invisible to it. A debug stylesheet
+      isn't a test suite, but it runs everywhere CSS runs: in the browser,
+      on any page, with zero tooling.
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss" src="./AuditStylesheet.scss"></style>


### PR DESCRIPTION
Wave 5: two new proof-pillar sections — a diagnostic-stylesheet demo (modern selectors painting a11y smells on an inert specimen, armed by a pure-CSS toggle) and a "performance is accessibility" prose block — plus the responsive-reveal extension on the @starting-style showcase (@starting-style inside a container query, with the reduced-motion guard the viral snippet omits, gated on motion rather than visibility).