### PR TITLE
eat: derive showcase grouping from Baseline data as three tiers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,72 +17,12 @@ git history and the PRs, not here.
 
 ---
 
-## The plan
+## Open
 
-Ordered waves, one branch each; work top to bottom.
+Nothing queued — the July 2026 wave plan is complete (see Done). New ideas
+land here.
 
-### Wave 1 — quick wins
-
-- `:user-valid` / `:user-invalid` showcase — stable tier; TextField already
-  uses it.
-- `light-dark()` beyond color — style-query trick for non-color values;
-  extends LightDarkDemo rather than a new entry.
-- CoverageMatrix row: "loading state never announced" (axe can't see it).
-
-### Wave 2 — container query units showcase
-
-- `cqi` + `clamp()` ultra-fluid components — formalizes what the timeline's
-  ghost numerals already dogfood.
-
-### Wave 3 — high-contrast presets (+ theming split)
-
-- High-contrast light/dark presets — the engine's grey mix strengths
-  (border 44% / subtle 62%) become per-theme data (a contrast-boost knob):
-  contrast as data, not duplicate palettes. Complements
-  `prefers-contrast: more` for users without the OS setting.
-- While in there: grow `theming.css` into `src/theming/`.
-
-### Wave 4 — "Break it with content" craft block
-
-- Stress-test a real component with a content switcher: designer-perfect
-  copy → long titles → German compound words → Arabic with `dir="rtl"`.
-  The RTL leg proves the logical-properties rigor already in the codebase
-  (`:dir()` styling, no left/right anywhere); the long-content legs show
-  the defensive guards absorbing it. Content variants via tiny Vue state
-  (simulated CMS — allowed). Inspired by Shadeed's "Breaking a Layout
-  Intentionally" (Debugging CSS, ch. 5) and his RTL Styling 101.
-
-### Wave 5 — The proof pillar pass (+ responsive-reveal card)
-
-- Extension card on the @starting-style showcase: the trick inside a
-  breakpoint — a hidden panel fades in when its container crosses a width
-  threshold instead of popping (`@starting-style` + `allow-discrete` inside
-  `@container`), slider-driven. Our version adds the guard the viral
-  snippet skips: reduced-motion gating (resize/rotation triggers it).
-  Inspired by @micka_design on X.
-
-- Diagnostic stylesheet ("CSS that audits") — a small debug stylesheet that
-  outlines a11y smells using modern selectors alone: `img:not([alt])`,
-  `a[target="_blank"]:not(:has(.visually-hidden))`, `button:empty`,
-  unlabeled inputs via `:not(:has(+ label))`. Shown against an intentionally
-  broken sample fragment; the selector engine as an audit tool.
-- "Performance is accessibility" prose block — compositor animation →
-  vestibular safety, main-thread health → SR responsiveness,
-  keystroke-level performance as a metric.
-
-### Wave 6 — pure-CSS carousel
-
-- Scroll buttons + `::scroll-marker`, presented WITH the current
-  screen-reader caveats (that honesty is the site's voice). Biggest build;
-  emerging tier.
-
-### Wave 7 — infra
-
-- Derive the stable/emerging grouping (and sidebar clusters) from the
-  Baseline data instead of the hand-maintained `status` field;
-  `baseline-watch` already flags transitions.
-
-### Conditional / Watchlist
+### Watchlist (too early / conditional — revisit)
 
 - Subgrid card alignment — only if criteria/showcase cards ever sit side by
   side; verify the layout before building.
@@ -119,6 +59,15 @@ Ordered waves, one branch each; work top to bottom.
 ## Done
 
 One line per item, newest first; details in git history / PRs.
+
+- **2026-07** Wave 7: showcase grouping derived from Baseline data — three tiers in Baseline's own vocabulary (widely / newly / limited availability), computed at build time; hand-maintained `status` field removed.
+- **2026-07** Wave 6: pure-CSS carousel showcase — `::scroll-button` (anchor-positioned) + `::scroll-marker` dots with slash-alt accessible names; honest SR caveats; plain snap scroller everywhere else.
+- **2026-07** Wave 5: proof pillar pass — "CSS that audits" diagnostic-stylesheet demo (inert specimen), "performance is accessibility" prose, responsive-reveal card on @starting-style (with the reduced-motion guard the viral snippet skips).
+- **2026-07** Wave 4: "Break it with content" craft block — one card vs. long titles, German compounds (hyphens + lang), Arabic RTL (:dir(), logical properties).
+- **2026-07** Toolbar glyphs replaced with inline SVGs (font-metric-proof centering).
+- **2026-07** Wave 3: high-contrast presets via engine `--mix-*` contrast knob; theming split into engine + presets files.
+- **2026-07** Wave 2: container query units showcase (`clamp(rem, cqi, rem)` fluid card).
+- **2026-07** Wave 1: `:user-valid` showcase, light-dark() style-query card, CoverageMatrix loading row; media pseudos parked (no Chromium).
 
 - **2026-07** Timeline content pass — Bypass Blocks (2.4.1) skip-link demo fills the WCAG 2.0 era; era summaries tightened.
 - **2026-07** Theme presets site-wide — seed engine promoted to `:root[data-preset]`, header popover panel (mode + presets + CVD trio), no-flash localStorage persistence; popover display trap fixed and pinned by e2e; `src` now 100% TypeScript.

--- a/src/App.vue
+++ b/src/App.vue
@@ -368,8 +368,9 @@
         </PillarHeader>
 
         <div class="demo">
-          <template v-for="group in groups" :key="group.status">
+          <template v-for="group in groups" :key="group.tier">
             <h3 v-if="group.items.length">{{ group.label }}</h3>
+            <p v-if="group.items.length">{{ group.blurb }}</p>
             <div class="showcase-list">
               <ShowcaseFrame
                 v-for="item in group.items"
@@ -555,16 +556,29 @@ const email = ref('')
 // JSON widens `baseline` to string|boolean; the generator guarantees the union.
 const baselineData = baselineDataJson as unknown as Record<string, BaselineInfo>
 
+// Tiers come straight from Baseline data (see registry.ts) — Baseline's own
+// vocabulary, so promotions happen at build time, not by hand.
 const groups = computed(() => [
   {
-    status: 'stable',
-    label: 'Widely supported',
-    items: showcases.filter((s) => s.status === 'stable'),
+    tier: 'widely-available',
+    label: 'Widely available',
+    blurb:
+      'Baseline widely available — in every engine for 30+ months. The foundation itself leans on these.',
+    items: showcases.filter((s) => s.tier === 'widely-available'),
   },
   {
-    status: 'emerging',
-    label: 'Emerging — Interop focus areas',
-    items: showcases.filter((s) => s.status === 'emerging'),
+    tier: 'newly-available',
+    label: 'Newly available',
+    blurb:
+      'Baseline newly available — interoperable everywhere, recently. Used with cheap fallbacks where it matters.',
+    items: showcases.filter((s) => s.tier === 'newly-available'),
+  },
+  {
+    tier: 'limited-availability',
+    label: 'Limited availability — Interop focus areas',
+    blurb:
+      'Not yet in every engine. Demos only, always behind @supports — they degrade instead of breaking.',
+    items: showcases.filter((s) => s.tier === 'limited-availability'),
   },
 ])
 
@@ -627,15 +641,21 @@ const toc: TocGroup[] = [
     // anchor ids stamped on each ShowcaseFrame above.
     subgroups: [
       {
-        label: 'Widely supported',
+        label: 'Widely available',
         sections: showcases
-          .filter((s) => s.status === 'stable')
+          .filter((s) => s.tier === 'widely-available')
           .map((s) => ({ id: `showcase-${s.id}`, label: s.title, summary: s.summary })),
       },
       {
-        label: 'Emerging',
+        label: 'Newly available',
         sections: showcases
-          .filter((s) => s.status === 'emerging')
+          .filter((s) => s.tier === 'newly-available')
+          .map((s) => ({ id: `showcase-${s.id}`, label: s.title, summary: s.summary })),
+      },
+      {
+        label: 'Limited availability',
+        sections: showcases
+          .filter((s) => s.tier === 'limited-availability')
           .map((s) => ({ id: `showcase-${s.id}`, label: s.title, summary: s.summary })),
       },
     ],

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -1,14 +1,16 @@
 /**
  * Showcase registry — single source of truth for the CSS showcases section;
- * App.vue renders this list grouped by status.
+ * App.vue renders this list grouped by Baseline tier.
  *
  * To add one: build a small demo under ./demos/ (one feature, new syntax behind
- * @supports with a fallback) plus a portable *.snippet.* excerpt, then add an
- * entry here.
+ * @supports with a fallback) plus a portable *.snippet.* excerpt, add an entry
+ * here, and map its id in scripts/gen-baseline.mjs.
  *
- * status: 'stable' = interoperable now (Baseline / done Interop areas), may be
- * used in the foundation itself; 'emerging' = active Interop area / partial
- * support, demo only, always progressive enhancement.
+ * tier is DERIVED from Baseline data at build time (gen-baseline.mjs →
+ * baseline-data.json), never hand-maintained: 'widely-available' (Baseline
+ * high) may be used in the foundation itself; 'newly-available' (Baseline low)
+ * is interoperable but recent; 'limited-availability' is demo-only, always
+ * behind @supports. File order only sets the order within each group.
  * supports = a CSS.supports() condition so ShowcaseFrame can tell visitors
  * whether they see the feature or the fallback ('' when none applies). For
  * JS APIs that CSS.supports() can't express, use `detect` instead.
@@ -16,6 +18,7 @@
  * Sources: https://wpt.fyi/interop-2026, https://web-platform-dx.github.io/web-features-explorer/
  */
 
+import baselineData from './baseline-data.json'
 import ContainerCardDemo from './demos/ContainerCardDemo/ContainerCardDemo.vue'
 import AnchorPopoverDemo from './demos/AnchorPopoverDemo/AnchorPopoverDemo.vue'
 import HasSelectorDemo from './demos/HasSelectorDemo/HasSelectorDemo.vue'
@@ -104,10 +107,12 @@ export interface BaselineInfo {
   support: Record<string, string | null>
 }
 
+export type BaselineTier = 'widely-available' | 'newly-available' | 'limited-availability'
+
 export interface Showcase {
   id: string
   title: string
-  status: 'stable' | 'emerging'
+  tier: BaselineTier
   supports: string
   /** JS feature test for APIs CSS.supports() can't express (View Transitions,
       Custom Highlight API). Takes precedence over `supports`. */
@@ -124,12 +129,11 @@ export interface Showcase {
   snippetJs?: string
 }
 
-export const showcases: Showcase[] = [
+const entries: Omit<Showcase, 'tier'>[] = [
   /* Stable — interoperable everywhere, fair game for the foundation. */
   {
     id: 'container-queries',
     title: 'Container queries',
-    status: 'stable',
     supports: 'container-type: inline-size',
     summary:
       'Components respond to the space they actually get instead of the ' +
@@ -149,7 +153,6 @@ export const showcases: Showcase[] = [
   {
     id: 'cq-units',
     title: 'Container query units',
-    status: 'stable',
     supports: 'width: 1cqi',
     summary:
       'The other half of container queries: cqi units inside clamp() scale ' +
@@ -169,7 +172,6 @@ export const showcases: Showcase[] = [
   {
     id: 'has-selector',
     title: ':has() relational selector',
-    status: 'stable',
     supports: 'selector(:has(a))',
     summary:
       'Style an element from its descendants’ state — something no ' +
@@ -189,7 +191,6 @@ export const showcases: Showcase[] = [
   {
     id: 'quantity-queries',
     title: 'Count-aware layouts (quantity queries)',
-    status: 'stable',
     supports: 'selector(:has(> :nth-child(2)))',
     summary:
       'The chat-app photo bundle, in pure CSS: the grid counts its own ' +
@@ -216,7 +217,6 @@ export const showcases: Showcase[] = [
   {
     id: 'subgrid',
     title: 'Subgrid',
-    status: 'stable',
     supports: 'grid-template-rows: subgrid',
     summary:
       'Nested grids adopt their parent’s tracks, so card internals ' +
@@ -234,7 +234,6 @@ export const showcases: Showcase[] = [
   {
     id: 'sliding-indicator',
     title: 'Sliding selection indicator',
-    status: 'stable',
     supports: 'selector(:has(*))',
     summary:
       'A modern way to visualize selection: one pill that travels between ' +
@@ -254,7 +253,6 @@ export const showcases: Showcase[] = [
   {
     id: 'text-wrap',
     title: 'text-wrap: balance / pretty',
-    status: 'stable',
     supports: 'text-wrap: balance',
     summary:
       'Let the browser decide line breaks. balance evens out short blocks ' +
@@ -272,7 +270,6 @@ export const showcases: Showcase[] = [
   {
     id: 'scroll-snap',
     title: 'Scroll snap',
-    status: 'stable',
     supports: 'scroll-snap-type: x mandatory',
     summary:
       'A horizontal strip where each card locks to centre as you scroll — ' +
@@ -293,7 +290,6 @@ export const showcases: Showcase[] = [
   {
     id: 'popover',
     title: 'Popover attribute',
-    status: 'stable',
     supports: '',
     summary:
       'A real actions menu wired by id alone — the platform hands you ' +
@@ -313,7 +309,6 @@ export const showcases: Showcase[] = [
   {
     id: 'user-valid',
     title: ':user-valid / :user-invalid',
-    status: 'stable',
     supports: 'selector(:user-valid)',
     summary:
       'Validation styling with manners — these pseudo-classes match only ' +
@@ -330,11 +325,9 @@ export const showcases: Showcase[] = [
     snippetCss: userValidSnippetCss,
   },
 
-  /* Emerging — Interop 2026 focus areas; demos only, behind @supports. */
   {
     id: 'anchor-positioning',
     title: 'Anchor positioning',
-    status: 'emerging',
     supports: 'anchor-name: --a',
     summary:
       'Tether a popover to the element that opened it, in pure CSS. ' +
@@ -358,7 +351,6 @@ export const showcases: Showcase[] = [
   {
     id: 'anchor-tooltip',
     title: 'Anchor-positioned tooltip',
-    status: 'emerging',
     supports: 'anchor-name: --a',
     summary:
       'A hover/focus hint tethered to its trigger with anchor positioning, ' +
@@ -384,7 +376,6 @@ export const showcases: Showcase[] = [
   {
     id: 'contrast-color',
     title: 'contrast-color()',
-    status: 'emerging',
     supports: 'color: contrast-color(red)',
     summary:
       'The browser picks a contrasting text color for any background — ' +
@@ -403,7 +394,6 @@ export const showcases: Showcase[] = [
   {
     id: 'theming',
     title: 'Contrast-safe theming',
-    status: 'emerging',
     supports: 'color: oklch(from red l c h)',
     summary:
       'One engine, many themes. Each theme is just two seed colors; the full ' +
@@ -426,7 +416,6 @@ export const showcases: Showcase[] = [
   {
     id: 'theme-picker',
     title: 'Contrast-clamped theme picker',
-    status: 'emerging',
     supports: 'color: oklch(from red l c h)',
     summary:
       'The same engine, made interactive: pick an accent and drag its ' +
@@ -450,7 +439,6 @@ export const showcases: Showcase[] = [
   {
     id: 'scroll-driven-animations',
     title: 'Scroll-driven animations',
-    status: 'emerging',
     supports: 'animation-timeline: scroll()',
     summary:
       'Animations driven by scroll position instead of time — no scroll ' +
@@ -469,7 +457,6 @@ export const showcases: Showcase[] = [
   {
     id: 'style-queries',
     title: 'Container style queries · non-color cues',
-    status: 'emerging',
     supports: '',
     summary:
       'Query a container’s custom-property value (not just its size) to ' +
@@ -492,7 +479,6 @@ export const showcases: Showcase[] = [
   {
     id: 'shape-function',
     title: 'shape()',
-    status: 'emerging',
     supports: 'clip-path: shape(from 0 0, line to 100% 0)',
     summary:
       'Responsive, keyword-based clip paths (lines, arcs, curves) that ' +
@@ -511,7 +497,6 @@ export const showcases: Showcase[] = [
   {
     id: 'starting-style',
     title: '@starting-style',
-    status: 'emerging',
     supports: 'transition-behavior: allow-discrete',
     summary:
       'Animate an element in from display:none — entry transitions with no ' +
@@ -531,7 +516,6 @@ export const showcases: Showcase[] = [
   {
     id: 'advanced-attr',
     title: 'Advanced attr()',
-    status: 'emerging',
     supports: 'width: calc(attr(data-value type(<number>), 0) * 1%)',
     summary:
       'attr() with types — read data attributes as lengths, colors, or ' +
@@ -551,7 +535,6 @@ export const showcases: Showcase[] = [
   {
     id: 'field-sizing',
     title: 'field-sizing: content',
-    status: 'emerging',
     supports: 'field-sizing: content',
     summary:
       'A textarea that grows and shrinks with its content — no scrollHeight ' +
@@ -571,7 +554,6 @@ export const showcases: Showcase[] = [
   {
     id: 'css-zoom',
     title: 'CSS zoom',
-    status: 'emerging',
     supports: 'zoom: 2',
     summary:
       'The newly-interoperable zoom property magnifies an element AND reflows ' +
@@ -591,7 +573,6 @@ export const showcases: Showcase[] = [
   {
     id: 'customizable-select',
     title: 'Customizable <select>',
-    status: 'emerging',
     supports: 'appearance: base-select',
     summary:
       'A native <select> opted into full CSS styling with appearance: ' +
@@ -615,7 +596,6 @@ export const showcases: Showcase[] = [
   {
     id: 'scroll-state',
     title: 'Scroll-state queries',
-    status: 'emerging',
     supports: 'container-type: scroll-state',
     summary:
       'Container queries that react to how an element sits in a scroller — ' +
@@ -639,7 +619,6 @@ export const showcases: Showcase[] = [
   {
     id: 'css-carousel',
     title: 'Pure-CSS carousel',
-    status: 'emerging',
     supports: 'selector(::scroll-marker)',
     summary:
       'Scroll buttons and marker dots generated entirely by CSS — focusable, ' +
@@ -660,7 +639,6 @@ export const showcases: Showcase[] = [
   {
     id: 'custom-highlight',
     title: 'Custom Highlight API',
-    status: 'emerging',
     supports: '',
     detect: () => 'highlights' in CSS,
     summary:
@@ -681,7 +659,6 @@ export const showcases: Showcase[] = [
   {
     id: 'dialog-polish',
     title: 'Dialog & popover niceties',
-    status: 'emerging',
     supports: 'selector(:open)',
     summary:
       'Newer overlay ergonomics: a popover="hint" toggletip (show + dismiss ' +
@@ -705,7 +682,6 @@ export const showcases: Showcase[] = [
   {
     id: 'interest-invokers',
     title: 'Interest invokers (interestfor)',
-    status: 'emerging',
     supports: 'interest-delay: 0s',
     summary:
       'Hover, keyboard focus, or touch long-press invokes a popover from one ' +
@@ -732,7 +708,6 @@ export const showcases: Showcase[] = [
   {
     id: 'view-transitions',
     title: 'View Transitions',
-    status: 'emerging',
     supports: '',
     detect: () => 'startViewTransition' in document,
     summary:
@@ -755,3 +730,12 @@ export const showcases: Showcase[] = [
   // Further candidates: media state pseudo-classes (custom player),
   // anchor-positioned tooltips, customizable <select>.
 ]
+
+const tierOf = (id: string): BaselineTier => {
+  const baseline = (baselineData as Record<string, BaselineInfo>)[id]?.baseline
+  if (baseline === 'high') return 'widely-available'
+  if (baseline === 'low') return 'newly-available'
+  return 'limited-availability'
+}
+
+export const showcases: Showcase[] = entries.map((e) => ({ ...e, tier: tierOf(e.id) }))


### PR DESCRIPTION
Wave 7 (final): the showcase status field is now derived, not declared — gen-baseline.mjs data maps Baseline high/low/false to three tiers presented in Baseline's own terms (widely / newly / limited availability). Sidebar clusters and page groups follow automatically; future Baseline promotions regroup the catalog at build time. Also collapses the completed wave plan in ROADMAP.md.