### PR TITLE
fix: theme switch in dark-mode section, phantom focus ring, Safari style-query cues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,8 +19,38 @@ git history and the PRs, not here.
 
 ## Open
 
-Nothing queued — the July 2026 wave plan is complete (see Done). New ideas
-land here.
+### Feedback inbox — July 2026 round
+
+Collected from friends and former colleagues after launch; triage into
+fixes/features as they come in.
+
+- ~~Theme switch reachable from the dark-mode craft section~~ — fixed:
+  shared theme state (composable), inline mode switcher in the demo.
+- ~~Phantom focus ring on the content column after closing a dialog
+  (iOS)~~ — fixed: `tabindex="-1"` containers no longer draw the ring.
+- ~~Non-color cues invisible in Safari~~ — fixed: WebKit doesn't apply
+  pseudo-element rules inside style queries; the query now sets `--cue`
+  on the element, the pseudo renders it. Snippet teaches the gotcha.
+- Showcase findability: tags/categories ("scroll", "forms", "theming")
+  with filter chips — candidate for a pure-CSS `:has()` filter. The
+  catalog is one long list; browsing ≠ finding.
+- Positioning check (Thomas's call): mobile tester read the showcase as
+  "you don't need JS" more than "accessible by default" — consider an
+  explicit a11y-payoff line per showcase card. Counterpoint: the
+  shareable "there's a native way" framing is exactly why he'd send it
+  to a JS-heavy friend.
+- "The standard" pillar gets skipped on mobile (showcase is more fun) —
+  editorial; maybe fine (different entries for different readers).
+- shape() demo: make it interactive — toggle between shapes, or contrast
+  shape() with a frozen path() side by side.
+- text-wrap demo: interactive too — show default vs balance/pretty one at
+  a time instead of stacked cards.
+- Timeline ghost year too subtle in the dark default theme (fine in
+  light/sunset) — stroke-contrast tune; decorative, so keep it quiet, but
+  "didn't notice 2008" defeats the orientation purpose.
+- iOS zoom-in/zoom-out sometimes lands in a different section — needs the
+  tester's video to reproduce; suspects: scroll anchoring vs sticky
+  ghosts / scroll-driven timelines.
 
 ### Watchlist (too early / conditional — revisit)
 

--- a/src/components/ThemeToggle/ThemeToggle.vue
+++ b/src/components/ThemeToggle/ThemeToggle.vue
@@ -49,73 +49,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { contrastPresets, cvdPresets, modes, presets, useSiteTheme } from './useSiteTheme'
 
-const modes = ['system', 'light', 'dark'] as const
-const presets = [
-  { value: 'ocean', label: 'Ocean' },
-  { value: 'midnight', label: 'Midnight' },
-  { value: 'sunset', label: 'Sunset' },
-] as const
-const cvdPresets = [
-  { value: 'cobalt', label: 'Cobalt' },
-  { value: 'teal', label: 'Teal' },
-  { value: 'amber', label: 'Amber' },
-] as const
-const contrastPresets = [
-  { value: 'contrast-light', label: 'Contrast light' },
-  { value: 'contrast-dark', label: 'Contrast dark' },
-] as const
-
-type Mode = (typeof modes)[number]
-type Preset =
-  | (typeof presets)[number]['value']
-  | (typeof cvdPresets)[number]['value']
-  | (typeof contrastPresets)[number]['value']
-type Theme = Mode | Preset
-
-const PRESET_VALUES: readonly string[] = [...presets, ...cvdPresets, ...contrastPresets].map(
-  (p) => p.value,
-)
-const STORAGE_KEY = 'abd-theme'
-
-// The inline script in index.html already applied the saved value pre-paint;
-// the ref starts from the DOM so UI and document never disagree.
-const initial = (): Theme => {
-  const root = document.documentElement
-  if (root.dataset.preset && PRESET_VALUES.includes(root.dataset.preset)) {
-    return root.dataset.preset as Theme
-  }
-  if (root.dataset.theme === 'light' || root.dataset.theme === 'dark') {
-    return root.dataset.theme
-  }
-  return 'system'
-}
-
-const theme = ref<Theme>(initial())
-
-watchEffect(() => {
-  const root = document.documentElement
-  if (PRESET_VALUES.includes(theme.value)) {
-    root.dataset.preset = theme.value
-    delete root.dataset.theme
-  } else if (theme.value === 'light' || theme.value === 'dark') {
-    root.dataset.theme = theme.value
-    delete root.dataset.preset
-  } else {
-    delete root.dataset.theme
-    delete root.dataset.preset
-  }
-  try {
-    if (theme.value === 'system') {
-      localStorage.removeItem(STORAGE_KEY)
-    } else {
-      localStorage.setItem(STORAGE_KEY, theme.value)
-    }
-  } catch {
-    /* storage unavailable (private mode) — theme still applies for the session */
-  }
-})
+const theme = useSiteTheme()
 </script>
 
 <style scoped lang="scss" src="./ThemeToggle.scss"></style>

--- a/src/components/ThemeToggle/useSiteTheme.ts
+++ b/src/components/ThemeToggle/useSiteTheme.ts
@@ -1,0 +1,72 @@
+import { ref, watchEffect } from 'vue'
+
+export const modes = ['system', 'light', 'dark'] as const
+export const presets = [
+  { value: 'ocean', label: 'Ocean' },
+  { value: 'midnight', label: 'Midnight' },
+  { value: 'sunset', label: 'Sunset' },
+] as const
+export const cvdPresets = [
+  { value: 'cobalt', label: 'Cobalt' },
+  { value: 'teal', label: 'Teal' },
+  { value: 'amber', label: 'Amber' },
+] as const
+export const contrastPresets = [
+  { value: 'contrast-light', label: 'Contrast light' },
+  { value: 'contrast-dark', label: 'Contrast dark' },
+] as const
+
+type Mode = (typeof modes)[number]
+type Preset =
+  | (typeof presets)[number]['value']
+  | (typeof cvdPresets)[number]['value']
+  | (typeof contrastPresets)[number]['value']
+export type Theme = Mode | Preset
+
+const PRESET_VALUES: readonly string[] = [...presets, ...cvdPresets, ...contrastPresets].map(
+  (p) => p.value,
+)
+const STORAGE_KEY = 'abd-theme'
+
+// The inline script in index.html already applied the saved value pre-paint;
+// state starts from the DOM so UI and document never disagree.
+const initial = (): Theme => {
+  const root = document.documentElement
+  if (root.dataset.preset && PRESET_VALUES.includes(root.dataset.preset)) {
+    return root.dataset.preset as Theme
+  }
+  if (root.dataset.theme === 'light' || root.dataset.theme === 'dark') {
+    return root.dataset.theme
+  }
+  return 'system'
+}
+
+// Module scope: one theme, however many controls bind to it.
+const theme = ref<Theme>(initial())
+
+watchEffect(() => {
+  const root = document.documentElement
+  if (PRESET_VALUES.includes(theme.value)) {
+    root.dataset.preset = theme.value
+    delete root.dataset.theme
+  } else if (theme.value === 'light' || theme.value === 'dark') {
+    root.dataset.theme = theme.value
+    delete root.dataset.preset
+  } else {
+    delete root.dataset.theme
+    delete root.dataset.preset
+  }
+  try {
+    if (theme.value === 'system') {
+      localStorage.removeItem(STORAGE_KEY)
+    } else {
+      localStorage.setItem(STORAGE_KEY, theme.value)
+    }
+  } catch {
+    /* storage unavailable (private mode) — theme still applies for the session */
+  }
+})
+
+export function useSiteTheme() {
+  return theme
+}

--- a/src/craft/demos/LightDarkDemo.vue
+++ b/src/craft/demos/LightDarkDemo.vue
@@ -2,14 +2,22 @@
   <div class="light-dark-demo">
     <p class="light-dark-caption">
       Two ways to give one swatch a light and a dark value. They look identical
-      at rest — until you <strong>flip the theme toggle in the header</strong>.
-      The <code>light-dark()</code> swatch follows your choice; the
+      at rest — until you <strong>flip the theme</strong>, right here. The
+      <code>light-dark()</code> swatch follows your choice; the
       <code>@media</code> swatch doesn't budge. That's the trap:
       <code>@media (prefers-color-scheme)</code> only listens to the
       <em>operating system</em>, so it silently ignores any in-app theme switch,
       while <code>light-dark()</code> resolves against <code>color-scheme</code>
       — the thing a theme toggle actually changes.
     </p>
+
+    <fieldset class="light-dark-switch">
+      <legend class="light-dark-switch-legend">Theme</legend>
+      <label v-for="mode in modes" :key="mode" class="light-dark-switch-option">
+        <input v-model="theme" type="radio" name="light-dark-theme" :value="mode" />
+        {{ mode }}
+      </label>
+    </fieldset>
 
     <div class="light-dark-grid">
       <article class="light-dark-card">
@@ -73,7 +81,11 @@
 </template>
 
 <script setup lang="ts">
-// No script needed — the whole point is that the theming is pure CSS.
+// The switcher is the same site-chrome control as the header's — the
+// mechanism being taught (light-dark() resolving color-scheme) stays pure CSS.
+import { modes, useSiteTheme } from '../../components/ThemeToggle/useSiteTheme'
+
+const theme = useSiteTheme()
 </script>
 
 <style scoped lang="scss">
@@ -92,6 +104,33 @@
   .light-dark-caption {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
+  }
+
+  .light-dark-switch {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    align-items: center;
+    justify-self: start;
+    margin: 0;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+  }
+
+  .light-dark-switch-legend {
+    float: inline-start;
+    padding-inline-end: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .light-dark-switch-option {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    text-transform: capitalize;
   }
 
   .light-dark-grid {

--- a/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.snippet.css
+++ b/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.snippet.css
@@ -8,8 +8,15 @@
 
 /* A style query reads the inherited value and adds a non-colour SHAPE to each
    status — so meaning never rests on colour alone. The status elements never
-   reference --cues; the query reaches them from their ancestor. */
+   reference --cues; the query reaches them from their ancestor.
+
+   Gotcha: keep pseudo-element rules OUT of the query — Safari doesn't apply
+   them there. Let the query set a variable, and the pseudo render it. */
+.status::before {
+  content: var(--cue, none);
+}
+
 @container style(--cues: on) {
-  .status--ok::before { content: '✓'; }
-  .status--down::before { content: '✕'; }
+  .status--ok { --cue: '✓'; }
+  .status--down { --cue: '✕'; }
 }

--- a/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.vue
+++ b/src/showcases/demos/StyleQueryCuesDemo/StyleQueryCuesDemo.vue
@@ -125,22 +125,28 @@ const services: { name: string; state: State }[] = [
   }
 
   /* Style query: when --cues is on (inherited), swap the dot for a SHAPE that
-     survives any colour-vision deficiency — no status element references --cues. */
+     survives any colour-vision deficiency — no status element references --cues.
+     The query sets --cue on the element and the pseudo renders it: WebKit
+     doesn't apply pseudo-element rules nested inside style queries. */
+  .service-status::before {
+    content: var(--cue, none);
+  }
+
   @container style(--cues: on) {
     .service-status {
       background-color: transparent;
       color: var(--state-color);
 
-      &--ok::before {
-        content: '✓';
+      &--ok {
+        --cue: '✓';
       }
 
-      &--degraded::before {
-        content: '▲';
+      &--degraded {
+        --cue: '▲';
       }
 
-      &--down::before {
-        content: '✕';
+      &--down {
+        --cue: '✕';
       }
     }
   }

--- a/src/styles/preferences.css
+++ b/src/styles/preferences.css
@@ -79,4 +79,11 @@
     outline:        var(--focus-ring-width) solid var(--focus-ring-color);
     outline-offset: var(--focus-ring-offset);
   }
+
+  /* tabindex="-1" containers (skip target, dialog-close fallback) only ever
+     receive focus programmatically — WebKit still ring-lights them, outlining
+     the whole column. Never reachable by Tab, so no indicator is lost. */
+  [tabindex='-1']:focus-visible {
+    outline: none;
+  }
 }


### PR DESCRIPTION
First post-launch feedback round: shared theme state via composable + inline switcher in the dark-mode craft section; no focus ring on tabindex="-1" containers (iOS dialog-close outlined the whole column); Safari style-query fix — WebKit drops pseudo-element rules inside style() queries, so the query now sets --cue and the pseudo renders it (snippet updated to teach the gotcha). Remaining feedback triaged into the ROADMAP inbox.