### PR TITLE
feat: add a11y payoff lines, topic filter, and style-guide theming se…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,13 +31,12 @@ fixes/features as they come in.
 - ~~Non-color cues invisible in Safari~~ — fixed: WebKit doesn't apply
   pseudo-element rules inside style queries; the query now sets `--cue`
   on the element, the pseudo renders it. Snippet teaches the gotcha.
-- Showcase findability: tags/categories ("scroll", "forms", "theming")
-  with filter chips — candidate for a pure-CSS `:has()` filter. The
-  catalog is one long list; browsing ≠ finding.
-- **A11y payoff line per showcase (approved)** — a dedicated, visually
-  distinct "why this is accessibility" line on every showcase card,
-  rebalancing the "you don't need JS" reading. New registry field +
-  ShowcaseFrame rendering + 29 lines of copy.
+- ~~Showcase findability~~ — done: 7 topic tags on all 29 entries,
+  pure-CSS `:has()` radio-chip filter, empty tier groups hide themselves.
+- ~~A11y payoff line per showcase~~ — done: `payoff` registry field, 29
+  lines of copy, distinct accessibility-marked line on every card.
+- ~~Style guide dormant~~ — done: live theming/presets section (renders
+  from the real `.theme-*` classes) + footer link.
 - "The standard" pillar could be more interesting/interactive — parked
   for now (Thomas); revisit with concrete ideas, not urgency.
 - shape() demo: make it interactive — toggle between shapes, or contrast
@@ -50,6 +49,12 @@ fixes/features as they come in.
 - iOS zoom-in/zoom-out sometimes lands in a different section — needs the
   tester's video to reproduce; suspects: scroll anchoring vs sticky
   ghosts / scroll-driven timelines.
+- "Motion that bows out on request" demo is a bit boring — rethink it
+  (AnimationDemo). Make the reduced-motion contrast more visceral / the
+  default motion more worth taming.
+- Loading spinner (AppSpinner / loading-states demo) low-contrast in some
+  themes — the wheel can wash out against certain seeds. Give it a
+  theme-aware track/contrast treatment.
 
 ### Watchlist (too early / conditional — revisit)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -368,26 +368,42 @@
         </PillarHeader>
 
         <div class="demo">
+          <fieldset class="showcase-filter">
+            <legend class="showcase-filter-legend">Filter by topic</legend>
+            <label class="showcase-filter-chip">
+              <input type="radio" name="showcase-filter" value="all" checked />
+              All
+            </label>
+            <label v-for="tag in showcaseTags" :key="tag" class="showcase-filter-chip">
+              <input type="radio" name="showcase-filter" :value="tag" />
+              {{ tag }}
+            </label>
+          </fieldset>
+
           <template v-for="group in groups" :key="group.tier">
-            <h3 v-if="group.items.length">{{ group.label }}</h3>
-            <p v-if="group.items.length">{{ group.blurb }}</p>
-            <div class="showcase-list">
-              <ShowcaseFrame
-                v-for="item in group.items"
-                :key="item.id"
-                :id="`showcase-${item.id}`"
-                :title="item.title"
-                :summary="item.summary"
-                :supports="item.supports"
-                :detect="item.detect"
-                :baseline="baselineData[item.id]"
-                :links="item.links"
-                :snippet-html="item.snippetHtml"
-                :snippet-css="item.snippetCss"
-                :snippet-js="item.snippetJs"
-              >
-                <component :is="item.component" v-bind="item.props" />
-              </ShowcaseFrame>
+            <div v-if="group.items.length" class="showcase-group">
+              <h3>{{ group.label }}</h3>
+              <p>{{ group.blurb }}</p>
+              <div class="showcase-list">
+                <ShowcaseFrame
+                  v-for="item in group.items"
+                  :key="item.id"
+                  :id="`showcase-${item.id}`"
+                  :data-tags="item.tags.join(' ')"
+                  :title="item.title"
+                  :summary="item.summary"
+                  :payoff="item.payoff"
+                  :supports="item.supports"
+                  :detect="item.detect"
+                  :baseline="baselineData[item.id]"
+                  :links="item.links"
+                  :snippet-html="item.snippetHtml"
+                  :snippet-css="item.snippetCss"
+                  :snippet-js="item.snippetJs"
+                >
+                  <component :is="item.component" v-bind="item.props" />
+                </ShowcaseFrame>
+              </div>
             </div>
           </template>
         </div>
@@ -515,6 +531,7 @@
       </details>
 
       <nav class="footer-meta" aria-label="Site information">
+        <a href="/styleguide.html">Style guide</a>
         <a href="/impressum.html">Impressum</a>
         <a href="/privacy.html">Privacy</a>
         <a href="https://github.com/ThomasSweet/a11y-foundation">GitHub</a>
@@ -558,6 +575,10 @@ const baselineData = baselineDataJson as unknown as Record<string, BaselineInfo>
 
 // Tiers come straight from Baseline data (see registry.ts) — Baseline's own
 // vocabulary, so promotions happen at build time, not by hand.
+// Values must exist in the $showcase-tags list in this file's styles — the
+// pure-CSS filter rules are generated from that list.
+const showcaseTags = ['layout', 'scroll', 'forms', 'theming', 'typography', 'interaction', 'motion']
+
 const groups = computed(() => [
   {
     tier: 'widely-available',
@@ -828,6 +849,57 @@ const toc: TocGroup[] = [
     gap: var(--space-6);
   }
 
+  .showcase-group {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .showcase-filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    border: none;
+  }
+
+  .showcase-filter-legend {
+    float: inline-start;
+    padding: 0;
+    padding-inline-end: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .showcase-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-full);
+    font-size: var(--text-sm);
+    text-transform: capitalize;
+    cursor: pointer;
+
+    &:has(input:checked) {
+      border-color: var(--color-primary);
+      background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+      font-weight: 600;
+    }
+
+    @include can-hover {
+      &:hover {
+        border-color: var(--color-text-subtle);
+      }
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
   .site-footer {
     display: grid;
     gap: var(--space-4);
@@ -850,6 +922,23 @@ const toc: TocGroup[] = [
      rules under .toc). Harmless where unused (desktop) or unsupported. */
   :global(html) {
     container-type: scroll-state;
+  }
+
+  /* Pure-CSS catalog filter — keep in sync with showcaseTags in the script.
+     Must live in `components`, not `layout`: the hide has to beat the cards'
+     own display in the same layer. */
+  $showcase-tags: layout, scroll, forms, theming, typography, interaction, motion;
+
+  @each $tag in $showcase-tags {
+    .demo:has(.showcase-filter input[value='#{$tag}']:checked) {
+      .showcase[data-tags]:not([data-tags~='#{$tag}']) {
+        display: none;
+      }
+
+      .showcase-group:not(:has(.showcase[data-tags~='#{$tag}'])) {
+        display: none;
+      }
+    }
   }
 
   .toc {
@@ -991,12 +1080,22 @@ const toc: TocGroup[] = [
     gap: var(--space-1);
     min-block-size: 44px;
     padding: var(--space-1);
-    border-radius: var(--radius-md);
+    /* Concentric with the pill, so an active background can never poke
+       past the pill's end curves. */
+    border-radius: var(--radius-full);
     font-weight: 600;
     color: var(--color-text-subtle);
     text-decoration: none;
     white-space: nowrap;
     text-align: center;
+    background-image: radial-gradient(
+      100% 130% at 50% 135%,
+      color-mix(in oklab, var(--color-primary) 30%, transparent),
+      transparent 72%
+    );
+    background-repeat: no-repeat;
+    background-position: center bottom;
+    background-size: 100% 0;
 
     @include from('lg') {
       flex-direction: row;
@@ -1007,6 +1106,7 @@ const toc: TocGroup[] = [
       padding: var(--space-1) var(--space-2);
       border-radius: var(--radius-sm);
       font-weight: 700;
+      background-image: none;
     }
 
     @include can-hover {
@@ -1194,17 +1294,35 @@ const toc: TocGroup[] = [
       animation-range: cover 0% cover 100%;
     }
 
+    /* Mobile pill: the accent glow rises with the section's own scroll
+       progress — the scrub is the state. */
     @keyframes toc-group-active {
       0%,
       100% {
-        background-color: transparent;
         color: var(--color-text-subtle);
+        background-size: 100% 0;
       }
 
       12%,
       88% {
-        background-color: var(--color-bg-subtle);
         color: var(--color-text);
+        background-size: 100% 100%;
+      }
+    }
+
+    @include from('lg') {
+      @keyframes toc-group-active {
+        0%,
+        100% {
+          background-color: transparent;
+          color: var(--color-text-subtle);
+        }
+
+        12%,
+        88% {
+          background-color: var(--color-bg-subtle);
+          color: var(--color-text);
+        }
       }
     }
 

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
@@ -43,6 +43,39 @@
     color: var(--color-text-subtle);
   }
 
+  .showcase-payoff {
+    display: flex;
+    gap: var(--space-2);
+    align-items: start;
+    padding: var(--space-2) var(--space-3);
+    border-inline-start: 3px solid var(--color-primary);
+    border-start-end-radius: var(--radius-sm);
+    border-end-end-radius: var(--radius-sm);
+    background-color: color-mix(in oklab, var(--color-primary) 7%, transparent);
+    font-size: var(--text-sm);
+
+    @include high-contrast {
+      border-color: currentcolor;
+      background-color: transparent;
+    }
+
+    @include forced-colors {
+      border: 1px solid CanvasText;
+    }
+  }
+
+  .showcase-payoff-icon {
+    flex: none;
+    inline-size: 1.15em;
+    block-size: 1.15em;
+    margin-block-start: 0.15em;
+    fill: var(--color-primary);
+
+    @include forced-colors {
+      fill: CanvasText;
+    }
+  }
+
   .showcase-unsupported {
     padding: var(--space-2) var(--space-3);
     border-inline-start: 3px solid var(--color-info);

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
@@ -8,6 +8,16 @@
 
     <p class="showcase-summary">{{ summary }}</p>
 
+    <p v-if="payoff" class="showcase-payoff">
+      <svg class="showcase-payoff-icon" viewBox="0 -960 960 960" aria-hidden="true">
+        <path
+          d="M480-720q-33 0-56.5-23.5T400-800q0-33 23.5-56.5T480-880q33 0 56.5 23.5T560-800q0 33-23.5 56.5T480-720ZM360-80v-520q-60-5-122-15t-118-25l20-80q78 21 166 30.5t174 9.5q86 0 174-9.5T820-720l20 80q-56 15-118 25t-122 15v520h-80v-240h-80v240h-80Z"
+        />
+      </svg>
+      <span class="visually-hidden">Accessibility payoff:</span>
+      <span>{{ payoff }}</span>
+    </p>
+
     <BaselineBadge v-if="baseline" :info="baseline" />
 
     <p v-if="!supported" class="showcase-unsupported" role="note">
@@ -83,6 +93,8 @@ const props = withDefaults(
   defineProps<{
     title: string
     summary: string
+    /** The card's accessibility-payoff line — who this helps and how. */
+    payoff?: string
     /** CSS.supports() condition for the feature, e.g. "container-type: inline-size". */
     supports?: string
     /** JS feature test for APIs CSS.supports() can't express (View Transitions,
@@ -102,6 +114,7 @@ const props = withDefaults(
   }>(),
   {
     supports: '',
+    payoff: '',
     links: () => [],
     headingLevel: 4,
     snippetHtml: '',

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -118,6 +118,12 @@ export interface Showcase {
       Custom Highlight API). Takes precedence over `supports`. */
   detect?: () => boolean
   summary: string
+  /** One sentence naming who the feature helps and how — rendered as the
+      card's distinct accessibility-payoff line. */
+  payoff: string
+  /** Topic tags for the catalog filter — values must exist in the
+      $showcase-tags list in App.vue's styles. */
+  tags: string[]
   links?: { label: string; href: string }[]
   component: Component
   props?: Record<string, unknown>
@@ -146,6 +152,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries',
       },
     ],
+    payoff:
+      'Layouts that adapt to their space survive 400% zoom and squeezed sidebars alike — low-vision users get reflow (1.4.10) for free.',
+    tags: ['layout'],
     component: ContainerCardDemo,
     snippetHtml: containerSnippetHtml,
     snippetCss: containerSnippetCss,
@@ -166,6 +175,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_size_and_style_queries#container_query_length_units',
       },
     ],
+    payoff:
+      'The rem bounds in every clamp() keep the user’s font-size preference in charge at any container width — no breakpoint ever overrides it.',
+    tags: ['layout', 'typography'],
     component: CqUnitsDemo,
     snippetCss: cqUnitsSnippetCss,
   },
@@ -184,6 +196,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:has',
       },
     ],
+    payoff:
+      ':has() styles states the DOM already knows — no JS class-toggling that can drift from the real, announced state.',
+    tags: ['interaction'],
     component: HasSelectorDemo,
     snippetHtml: hasSnippetHtml,
     snippetCss: hasSnippetCss,
@@ -210,6 +225,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://alistapart.com/article/quantity-queries-for-css/',
       },
     ],
+    payoff:
+      'Count-aware layout keeps items at usable sizes however many a CMS delivers — target size (2.5.8) survives real content.',
+    tags: ['layout'],
     component: QuantityQueriesDemo,
     snippetHtml: quantitySnippetHtml,
     snippetCss: quantitySnippetCss,
@@ -228,6 +246,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid',
       },
     ],
+    payoff:
+      'Aligned tracks across cards keep visual order and reading order identical — what a screen reader announces matches what eyes scan.',
+    tags: ['layout'],
     component: SubgridDemo,
     snippetCss: subgridSnippetCss,
   },
@@ -246,6 +267,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:has',
       },
     ],
+    payoff:
+      'The moving highlight is a native radio group underneath — arrow keys, focus, and announcements come from the platform; only the paint animates.',
+    tags: ['interaction', 'motion'],
     component: SlidingIndicatorDemo,
     snippetHtml: slidingSnippetHtml,
     snippetCss: slidingSnippetCss,
@@ -264,6 +288,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap',
       },
     ],
+    payoff:
+      'Better line breaks with zero extra markup — nothing for assistive tech to trip on, and headings stay balanced at every zoom level.',
+    tags: ['typography'],
     component: TextWrapDemo,
     snippetCss: textWrapSnippetCss,
   },
@@ -283,6 +310,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll_snap',
       },
     ],
+    payoff:
+      'Snap points give wheel, touch, and keyboard scrolling the same stopping places — no JS carousel intercepting arrow keys.',
+    tags: ['scroll'],
     component: ScrollSnapDemo,
     snippetHtml: scrollSnapSnippetHtml,
     snippetCss: scrollSnapSnippetCss,
@@ -303,6 +333,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/API/Popover_API',
       },
     ],
+    payoff:
+      'Esc-to-close, light dismiss, and aria-expanded come with the attribute — the keyboard traps of hand-rolled dropdowns never exist.',
+    tags: ['interaction'],
     component: PopoverMenuDemo,
     snippetHtml: popoverSnippetHtml,
   },
@@ -321,6 +354,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid',
       },
     ],
+    payoff:
+      'Errors wait until someone has actually been in the field — no red flags shouting at screen-magnifier users before they’ve typed a character.',
+    tags: ['forms'],
     component: UserValidDemo,
     snippetCss: userValidSnippetCss,
   },
@@ -344,6 +380,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://wpt.fyi/interop-2026',
       },
     ],
+    payoff:
+      'Tethered UI repositions instead of clipping at viewport edges — magnified and small-screen users keep the attached panel on screen.',
+    tags: ['layout', 'interaction'],
     component: AnchorPopoverDemo,
     snippetHtml: anchorPopoverSnippetHtml,
     snippetCss: anchorPopoverSnippetCss,
@@ -369,6 +408,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html',
       },
     ],
+    payoff:
+      'Position fallbacks flip the tooltip into view at any zoom, and the pattern stays hoverable and dismissible (1.4.13).',
+    tags: ['interaction'],
     component: AnchorTooltipDemo,
     snippetHtml: anchorTooltipSnippetHtml,
     snippetCss: anchorTooltipSnippetCss,
@@ -388,6 +430,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color',
       },
     ],
+    payoff:
+      'The browser computes the readable label color for any background — text contrast becomes a guarantee, not a design-review catch.',
+    tags: ['theming'],
     component: ContrastColorDemo,
     snippetCss: contrastColorSnippetCss,
   },
@@ -410,6 +455,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color',
       },
     ],
+    payoff:
+      'Every derived palette flips text to black or white against its seed — a theme cannot accidentally ship unreadable text (1.4.3 by construction).',
+    tags: ['theming'],
     component: ThemeShowcaseDemo,
     snippetCss: themingSnippetCss,
   },
@@ -433,6 +481,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html',
       },
     ],
+    payoff:
+      'User color choices are clamped into the contrast-safe range — personalization without letting anyone pick their way into failure.',
+    tags: ['theming', 'forms'],
     component: ThemePickerDemo,
     snippetCss: themePickerSnippetCss,
   },
@@ -451,6 +502,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations',
       },
     ],
+    payoff:
+      'Scroll effects run off the main thread and collapse under prefers-reduced-motion — vestibular safety without losing the flourish.',
+    tags: ['scroll', 'motion'],
     component: ScrollProgressDemo,
     snippetCss: scrollProgressSnippetCss,
   },
@@ -473,6 +527,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html',
       },
     ],
+    payoff:
+      'Non-color cues switch on from one inherited flag — meaning stops resting on color alone (1.4.1) with no per-component code.',
+    tags: ['theming'],
     component: StyleQueryCuesDemo,
     snippetCss: styleQuerySnippetCss,
   },
@@ -491,6 +548,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/shape',
       },
     ],
+    payoff:
+      'The decorative clip never touches the text flow — zoom, reflow, and screen readers meet ordinary paragraphs underneath.',
+    tags: ['layout'],
     component: ShapeDemo,
     snippetCss: shapeSnippetCss,
   },
@@ -510,6 +570,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style',
       },
     ],
+    payoff:
+      'Entry and exit animate without JS timers — and display:none keeps closed panels truly gone from the accessibility tree, not just faded.',
+    tags: ['motion'],
     component: StartingStyleDemo,
     snippetCss: startingStyleSnippetCss,
   },
@@ -528,6 +591,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/attr',
       },
     ],
+    payoff:
+      'The styling reads the same attribute assistive tech could expose — one source of truth for the visual and the announced value.',
+    tags: ['layout'],
     component: AttrDemo,
     snippetHtml: attrSnippetHtml,
     snippetCss: attrSnippetCss,
@@ -547,6 +613,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing',
       },
     ],
+    payoff:
+      'Inputs grow with their content — screen-magnifier users see their whole answer instead of text scrolling out of a fixed box.',
+    tags: ['forms'],
     component: FieldSizingDemo,
     snippetHtml: fieldSizingSnippetHtml,
     snippetCss: fieldSizingSnippetCss,
@@ -567,6 +636,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/zoom',
       },
     ],
+    payoff:
+      'zoom scales a component the way real users magnify — a one-line testing lens for reflow and text-resize criteria.',
+    tags: ['layout'],
     component: ZoomCompareDemo,
     snippetCss: zoomSnippetCss,
   },
@@ -589,6 +661,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Learn/Forms/Customizable_select',
       },
     ],
+    payoff:
+      'Styled options on a real <select> — the keyboard model, mobile pickers, and screen-reader semantics stay native instead of ARIA-rebuilt.',
+    tags: ['forms'],
     component: CustomSelectDemo,
     snippetHtml: customSelectSnippetHtml,
     snippetCss: customSelectSnippetCss,
@@ -613,6 +688,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://wpt.fyi/interop-2026',
       },
     ],
+    payoff:
+      'The bar reacts to scrolling via CSS state, not scroll listeners — the main thread stays free, so assistive tech stays responsive.',
+    tags: ['scroll'],
     component: ScrollStateDemo,
     snippetCss: scrollStateSnippetCss,
   },
@@ -633,6 +711,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::scroll-marker',
       },
     ],
+    payoff:
+      'The generated buttons and dots are focusable and named — and without support it stays a keyboard-scrollable region, never a dead widget.',
+    tags: ['scroll', 'interaction'],
     component: CssCarouselDemo,
     snippetCss: cssCarouselSnippetCss,
   },
@@ -652,6 +733,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API',
       },
     ],
+    payoff:
+      'Highlights paint without wrapping spans — the text a screen reader reads is untouched by the visual layer.',
+    tags: ['typography'],
     component: HighlightApiDemo,
     snippetCss: highlightSnippetCss,
     snippetJs: highlightSnippetJs,
@@ -675,6 +759,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:open',
       },
     ],
+    payoff:
+      'showModal() brings focus trapping, Esc, and an inert background from the platform — the three things hand-rolled modals get wrong.',
+    tags: ['interaction'],
     component: DialogPolishDemo,
     snippetHtml: dialogPolishSnippetHtml,
     snippetCss: dialogPolishSnippetCss,
@@ -700,6 +787,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://chromestatus.com/feature/4530756656562176',
       },
     ],
+    payoff:
+      'Hover previews with built-in delays, keyboard parity, and Esc — the hover-only tooltip failures of 1.4.13, handled by an attribute.',
+    tags: ['interaction'],
     component: InterestInvokerDemo,
     snippetHtml: interestSnippetHtml,
     snippetCss: interestSnippetCss,
@@ -722,6 +812,9 @@ const entries: Omit<Showcase, 'tier'>[] = [
         href: 'https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API',
       },
     ],
+    payoff:
+      'Cross-page continuity as pure enhancement — reduced-motion users get an ordinary navigation, and no JS router is required at all.',
+    tags: ['motion'],
     component: ViewTransitionDemo,
     snippetCss: viewTransitionSnippetCss,
     snippetJs: viewTransitionSnippetJs,

--- a/src/styleguide/styleguide.scss
+++ b/src/styleguide/styleguide.scss
@@ -335,3 +335,36 @@
     margin-inline-start: auto;
   }
 }
+
+@layer components {
+  .presets {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+    gap: var(--space-3);
+    margin: var(--space-4) 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .preset {
+    display: grid;
+    gap: var(--space-2);
+    justify-items: start;
+  }
+
+  .preset-name {
+    font-weight: 600;
+  }
+
+  .preset-chip {
+    inline-size: var(--space-8);
+    block-size: var(--space-3);
+    border-radius: var(--radius-full);
+    background-color: var(--color-primary);
+  }
+
+  .preset-class {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}

--- a/styleguide.html
+++ b/styleguide.html
@@ -145,6 +145,77 @@
           </ul>
         </section>
 
+        <!-- ================================================ Theming -->
+        <section class="guide-section" aria-labelledby="sg-theming">
+          <h2 id="sg-theming">Theming</h2>
+          <p class="guide-note">
+            A theme is two OKLCH seeds — <code>--seed-surface</code> and
+            <code>--seed-accent</code> — plus optional <code>--mix-*</code>
+            contrast strengths; <code>theming/engine.css</code> derives the
+            full contrast-safe palette from them (text flips to black or
+            white against its seed, greys mix toward the text). The cards
+            below render from their real <code>.theme-*</code> classes, so
+            this page can't drift from the shipped values.
+          </p>
+
+          <ul class="presets" role="list">
+            <li class="surface preset">
+              <span class="preset-name">Default</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.surface</code>
+            </li>
+            <li class="surface theme-ocean preset">
+              <span class="preset-name">Ocean</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-ocean</code>
+            </li>
+            <li class="surface theme-midnight preset">
+              <span class="preset-name">Midnight</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-midnight</code>
+            </li>
+            <li class="surface theme-sunset preset">
+              <span class="preset-name">Sunset</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-sunset</code>
+            </li>
+            <li class="surface theme-cobalt preset">
+              <span class="preset-name">Cobalt</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-cobalt</code>
+            </li>
+            <li class="surface theme-teal preset">
+              <span class="preset-name">Teal</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-teal</code>
+            </li>
+            <li class="surface theme-amber preset">
+              <span class="preset-name">Amber</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-amber</code>
+            </li>
+            <li class="surface theme-contrast-light preset">
+              <span class="preset-name">Contrast light</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-contrast-light</code>
+            </li>
+            <li class="surface theme-contrast-dark preset">
+              <span class="preset-name">Contrast dark</span>
+              <span class="preset-chip" aria-hidden="true"></span>
+              <code class="preset-class">.theme-contrast-dark</code>
+            </li>
+          </ul>
+
+          <p class="guide-note">
+            Cobalt, Teal, and Amber are tuned for colour-vision deficiency —
+            lightness carries the signal, never hue alone. The Contrast pair
+            raises the engine's <code>--mix-*</code> strengths and widens the
+            focus ring: high contrast as data, not a duplicate palette. All
+            eight ship in the site header's theme panel, persisted with a
+            no-flash reload.
+          </p>
+        </section>
+
         <!-- ================================================ Typography -->
         <section class="guide-section" aria-labelledby="sg-type">
           <h2 id="sg-type">Typography</h2>


### PR DESCRIPTION
…ction

Feedback round 2a: a payoff field on all 29 showcases rendered as a distinct accessibility line per card (rebalances the "you don't need JS" reading); 7 topic tags with a pure-CSS :has() radio-chip filter (empty tier groups self-hide; sidebar links to filtered cards are a known ephemeral limitation); style guide gains a live theming/presets section and a footer link. Filter rules live in the components layer deliberately — layout loses that cascade fight.