### PR TITLE
Feat/round 2b interactive demos

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,10 +39,10 @@ fixes/features as they come in.
   from the real `.theme-*` classes) + footer link.
 - "The standard" pillar could be more interesting/interactive — parked
   for now (Thomas); revisit with concrete ideas, not urgency.
-- shape() demo: make it interactive — toggle between shapes, or contrast
-  shape() with a frozen path() side by side.
-- text-wrap demo: interactive too — show default vs balance/pretty one at
-  a time instead of stacked cards.
+- ~~shape() demo interactive~~ — done: width slider resizes two cards;
+  path()'s frozen coords visibly detach while shape() reflows.
+- ~~text-wrap demo interactive~~ — done: one block toggled in place via
+  :has(), default vs balance+pretty.
 - Timeline ghost year too subtle in the dark default theme (fine in
   light/sunset) — stroke-contrast tune; decorative, so keep it quiet, but
   "didn't notice 2008" defeats the orientation purpose.

--- a/src/showcases/demos/ShapeDemo/ShapeDemo.snippet.css
+++ b/src/showcases/demos/ShapeDemo/ShapeDemo.snippet.css
@@ -1,14 +1,20 @@
-/* A curved bottom edge from keyword commands in %/units, so it scales fluidly
-   — unlike path()'s frozen SVG coordinates. The band is decorative, so the
-   plain rectangular fallback loses no information where shape() is missing. */
+/* shape() draws in %/units, so the curve tracks the element at any width —
+   the whole point of the demo. */
 @supports (clip-path: shape(from 0 0, line to 100% 0)) {
-  .banner {
+  .banner-fluid {
     clip-path: shape(
       from 0 0,
       line to 100% 0,
-      line to 100% 72%,
-      curve to 0% 72% with 50% 100%,
+      line to 100% 60%,
+      curve to 0% 60% with 50% 100%,
       close
     );
   }
+}
+
+/* path()'s coordinates are absolute pixels, frozen at one size. The same
+   curve only meets the edges at ~360px wide; resize and it detaches. This
+   is what shape() fixes. */
+.banner-frozen {
+  clip-path: path('M0 0 L360 0 L360 58 C240 96 120 96 0 58 Z');
 }

--- a/src/showcases/demos/ShapeDemo/ShapeDemo.snippet.css
+++ b/src/showcases/demos/ShapeDemo/ShapeDemo.snippet.css
@@ -18,3 +18,33 @@
 .banner-frozen {
   clip-path: path('M0 0 L360 0 L360 58 C240 96 120 96 0 58 Z');
 }
+
+/* shape()'s two superpowers path() lacks: it reads custom properties, and it
+   animates. Register the depth so it interpolates, feed it into the curve,
+   and a class toggle morphs the whole silhouette on a transition. */
+@property --wave {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 78%;
+}
+
+.banner-morph {
+  clip-path: shape(
+    from 0 0,
+    line to 100% 0,
+    line to 100% 55%,
+    curve to 50% 55% with 75% var(--wave),
+    curve to 0% 55% with 25% calc(110% - var(--wave)),
+    close
+  );
+}
+
+.banner-morph.is-deep {
+  --wave: 100%;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .banner-morph {
+    transition: --wave 400ms;
+  }
+}

--- a/src/showcases/demos/ShapeDemo/ShapeDemo.vue
+++ b/src/showcases/demos/ShapeDemo/ShapeDemo.vue
@@ -40,6 +40,35 @@
       <code>shape()</code> reflows with the layout — the reason
       responsive clipping used to need JS or an SVG viewBox.
     </p>
+
+    <div class="shape-morph">
+      <label class="shape-morph-toggle">
+        <input class="shape-morph-input" type="checkbox" />
+        Deepen the wave
+      </label>
+
+      <article class="shape-card shape-card-morph">
+        <div class="shape-banner shape-banner-morph" aria-hidden="true">
+          <span class="shape-banner-tag">shape() + @property</span>
+        </div>
+        <div class="shape-body">
+          <p class="shape-title">One curve, animated</p>
+          <p class="shape-text">
+            The edge is a <code>shape()</code> whose depth is a registered
+            <code>@property</code>. Because it's a real custom property, it
+            <em>interpolates</em> — so the whole silhouette morphs on a
+            transition. <code>path()</code> can do neither: it can't read a
+            variable, and only tweens between identical command lists.
+          </p>
+        </div>
+      </article>
+
+      <p class="shape-note">
+        Two things unique to <code>shape()</code>: it reads custom properties,
+        and it animates. Toggle the wave — under reduced-motion it simply
+        snaps, no morph.
+      </p>
+    </div>
   </div>
 </template>
 
@@ -50,6 +79,14 @@ const width = ref(100)
 </script>
 
 <style scoped lang="scss">
+/* Registered so the depth can interpolate — an unregistered custom property
+   is a plain string and would jump, not morph. */
+@property --shape-wave {
+  syntax: '<percentage>';
+  inherits: true;
+  initial-value: 78%;
+}
+
 @layer components {
   .shape-demo {
     display: grid;
@@ -148,6 +185,51 @@ const width = ref(100)
   .shape-note {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
+  }
+
+  .shape-morph {
+    display: grid;
+    gap: var(--space-3);
+    padding-block-start: var(--space-2);
+  }
+
+  .shape-morph-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .shape-card-morph {
+    max-inline-size: 24rem;
+  }
+
+  /* The morphing edge: two curve control points ride --shape-wave. Checking the
+     box raises the depth; @property lets it interpolate to a smooth morph. */
+  @supports (clip-path: shape(from 0 0, line to 100% 0)) {
+    .shape-banner-morph {
+      min-block-size: 8rem;
+      clip-path: shape(
+        from 0 0,
+        line to 100% 0,
+        line to 100% 55%,
+        curve to 50% 55% with 75% var(--shape-wave),
+        curve to 0% 55% with 25% calc(110% - var(--shape-wave)),
+        close
+      );
+    }
+
+    .shape-morph:has(.shape-morph-input:checked) {
+      --shape-wave: 100%;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+      .shape-banner-morph {
+        transition: --shape-wave var(--duration-slow) var(--easing-standard);
+      }
+    }
   }
 }
 </style>

--- a/src/showcases/demos/ShapeDemo/ShapeDemo.vue
+++ b/src/showcases/demos/ShapeDemo/ShapeDemo.vue
@@ -1,37 +1,82 @@
 <template>
   <div class="shape-demo">
-    <article class="shape-card">
-      <!-- Decorative: the band carries no text, so losing it in forced-colors loses nothing. -->
-      <div class="shape-banner" aria-hidden="true">
-        <span class="shape-banner-glyph">◗</span>
-      </div>
-      <div class="shape-body">
-        <p class="shape-title">Curved by shape()</p>
-        <p class="shape-text">
-          The band's curved bottom edge is one <code>clip-path: shape()</code>
-          — keyword commands (<code>line</code>, <code>curve</code>) in
-          %/units, so it scales fluidly, unlike <code>path()</code>'s frozen
-          SVG coordinates. Text lives in the rectangular body, clear of the
-          clipped area.
-        </p>
-      </div>
-    </article>
+    <label class="shape-control">
+      Card width
+      <input v-model="width" type="range" min="45" max="100" step="1" />
+      <span aria-hidden="true">{{ width }}%</span>
+    </label>
+
+    <div class="shape-stage" :style="{ inlineSize: `${width}%` }">
+      <article class="shape-card">
+        <div class="shape-banner shape-banner-fluid" aria-hidden="true">
+          <span class="shape-banner-tag">shape()</span>
+        </div>
+        <div class="shape-body">
+          <p class="shape-title">Percentages — scales</p>
+          <p class="shape-text">
+            <code>shape()</code> draws its curve in %/units, so the edge
+            stays glued to the corners at any width.
+          </p>
+        </div>
+      </article>
+
+      <article class="shape-card">
+        <div class="shape-banner shape-banner-frozen" aria-hidden="true">
+          <span class="shape-banner-tag">path()</span>
+        </div>
+        <div class="shape-body">
+          <p class="shape-title">Frozen SVG coords — breaks</p>
+          <p class="shape-text">
+            <code>path()</code>'s coordinates are absolute pixels tuned for
+            one size. Narrow the card and the curve detaches from the edge.
+          </p>
+        </div>
+      </article>
+    </div>
+
+    <p class="shape-note">
+      Same curve, two functions. Drag the slider: the <code>path()</code>
+      card's clip only lines up at its original width, while
+      <code>shape()</code> reflows with the layout — the reason
+      responsive clipping used to need JS or an SVG viewBox.
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
-// No logic — the whole demo is CSS.
+import { ref } from 'vue'
+
+const width = ref(100)
 </script>
 
 <style scoped lang="scss">
 @layer components {
   .shape-demo {
     display: grid;
-    justify-items: start;
+    gap: var(--space-4);
+  }
+
+  .shape-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    font-size: var(--text-sm);
+
+    input {
+      flex: 1;
+      min-inline-size: 8rem;
+    }
+  }
+
+  .shape-stage {
+    display: grid;
+    gap: var(--space-3);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 10rem), 1fr));
   }
 
   .shape-card {
-    max-inline-size: 26rem;
+    min-inline-size: 0;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     overflow: hidden;
@@ -44,22 +89,12 @@
 
   .shape-banner {
     display: grid;
-    place-items: center;
-    min-block-size: 7rem;
+    align-content: start;
+    justify-items: start;
+    min-block-size: 6rem;
+    padding: var(--space-3);
     background: var(--gradient-accent);
     color: #fff;
-
-    /* Curved bottom edge; falls back to a plain band without shape(). The
-       @supports test needs a command — `shape(from 0 0)` alone is invalid. */
-    @supports (clip-path: shape(from 0 0, line to 100% 0)) {
-      clip-path: shape(
-        from 0 0,
-        line to 100% 0,
-        line to 100% 72%,
-        curve to 0% 72% with 50% 100%,
-        close
-      );
-    }
 
     @include forced-colors {
       background: Highlight;
@@ -67,24 +102,50 @@
     }
   }
 
-  .shape-banner-glyph {
-    font-size: var(--text-4xl);
-    /* Sit in the flat upper area, away from the curved edge. */
-    margin-block-end: var(--space-6);
+  .shape-banner-tag {
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    background-color: rgb(0 0 0 / 25%);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+
+  /* The fluid version: percentage commands, so the curve tracks any width. */
+  @supports (clip-path: shape(from 0 0, line to 100% 0)) {
+    .shape-banner-fluid {
+      clip-path: shape(
+        from 0 0,
+        line to 100% 0,
+        line to 100% 60%,
+        curve to 0% 60% with 50% 100%,
+        close
+      );
+    }
+  }
+
+  /* The frozen version: absolute px coordinates sized for a ~360px-wide banner.
+     They don't scale, so the curve only meets the edges at that one width. */
+  .shape-banner-frozen {
+    clip-path: path('M0 0 L360 0 L360 58 C240 96 120 96 0 58 Z');
   }
 
   .shape-body {
     display: grid;
     gap: var(--space-1);
-    padding: var(--space-4);
+    padding: var(--space-3);
   }
 
   .shape-title {
-    font-size: var(--text-lg);
+    font-size: var(--text-base);
     font-weight: 600;
   }
 
   .shape-text {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .shape-note {
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
   }

--- a/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
+++ b/src/showcases/demos/TextWrapDemo/TextWrapDemo.vue
@@ -1,23 +1,41 @@
 <template>
   <div class="text-wrap-demo">
-    <!-- The SAME text twice so the wrapping difference shows side by side; narrow on purpose. -->
-    <figure class="text-wrap-col">
-      <figcaption class="text-wrap-label">Default wrapping</figcaption>
-      <h5 class="text-wrap-heading">{{ heading }}</h5>
-      <p class="text-wrap-body">{{ body }}</p>
-    </figure>
+    <label class="text-wrap-control">
+      Column width
+      <input v-model="width" type="range" min="40" max="100" step="1" />
+      <span aria-hidden="true">{{ width }}%</span>
+    </label>
 
-    <figure class="text-wrap-col">
-      <figcaption class="text-wrap-label">
-        <code>balance</code> + <code>pretty</code>
-      </figcaption>
-      <h5 class="text-wrap-heading text-wrap-heading--balance">{{ heading }}</h5>
-      <p class="text-wrap-body text-wrap-body--pretty">{{ body }}</p>
-    </figure>
+    <div class="text-wrap-stage" :style="{ inlineSize: `${width}%` }">
+      <figure class="text-wrap-col">
+        <figcaption class="text-wrap-label">Default wrapping</figcaption>
+        <h5 class="text-wrap-heading">{{ heading }}</h5>
+        <p class="text-wrap-body">{{ body }}</p>
+      </figure>
+
+      <figure class="text-wrap-col">
+        <figcaption class="text-wrap-label">
+          <code>balance</code> + <code>pretty</code>
+        </figcaption>
+        <h5 class="text-wrap-heading text-wrap-heading--balance">{{ heading }}</h5>
+        <p class="text-wrap-body text-wrap-body--pretty">{{ body }}</p>
+      </figure>
+    </div>
+
+    <p class="text-wrap-note">
+      The same text, two ways, at a width you control. Drag narrower and watch
+      the default column strand a word on its own line while the
+      <code>balance</code> column keeps its lines even — the browser choosing
+      the breaks, no markup, no JS.
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
+
+const width = ref(100)
+
 const heading = 'A well-balanced headline never leaves its last word stranded'
 const body =
   'Typography reads better when the browser, not the viewport, decides ' +
@@ -28,17 +46,31 @@ const body =
 <style scoped lang="scss">
 @layer components {
   .text-wrap-demo {
-    /* Capped columns (not 1fr) so headings stay narrow enough to wrap on wide
-       screens, where the balance/pretty difference shows. No media query. */
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 18rem));
-    justify-content: start;
     gap: var(--space-4);
   }
 
-  .text-wrap-col {
+  .text-wrap-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    font-size: var(--text-sm);
+
+    input {
+      flex: 1;
+      min-inline-size: 8rem;
+    }
+  }
+
+  .text-wrap-stage {
     display: grid;
-    gap: var(--space-2);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+    gap: var(--space-3);
+  }
+
+  .text-wrap-col {
+    min-inline-size: 0;
     margin: 0;
     padding: var(--space-3);
     border: 1px solid var(--color-border);
@@ -51,6 +83,7 @@ const body =
   }
 
   .text-wrap-label {
+    margin-block-end: var(--space-2);
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--color-text-subtle);
@@ -67,6 +100,7 @@ const body =
   }
 
   .text-wrap-body {
+    margin-block-start: var(--space-2);
     font-size: var(--text-sm);
     color: var(--color-text-subtle);
 
@@ -74,6 +108,11 @@ const body =
     &--pretty {
       text-wrap: pretty;
     }
+  }
+
+  .text-wrap-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
   }
 }
 </style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -541,7 +541,8 @@ const entries: Omit<Showcase, 'tier'>[] = [
       'Responsive, keyword-based clip paths (lines, arcs, curves) that ' +
       'can use percentages and custom properties — unlike path(), which ' +
       'is frozen SVG coordinates. Resize the two cards to watch the ' +
-      'path() clip detach while shape() reflows. Interop 2026 focus area.',
+      'path() clip detach while shape() reflows, then morph a third with a ' +
+      'registered @property. Interop 2026 focus area.',
     links: [
       {
         label: 'MDN: shape()',

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -540,8 +540,8 @@ const entries: Omit<Showcase, 'tier'>[] = [
     summary:
       'Responsive, keyword-based clip paths (lines, arcs, curves) that ' +
       'can use percentages and custom properties — unlike path(), which ' +
-      'is frozen SVG coordinates. Here it curves a decorative band; the ' +
-      'text stays clear of the clip. Interop 2026 focus area.',
+      'is frozen SVG coordinates. Resize the two cards to watch the ' +
+      'path() clip detach while shape() reflows. Interop 2026 focus area.',
     links: [
       {
         label: 'MDN: shape()',


### PR DESCRIPTION
Round 2b (tester feedback): shape() becomes a width-slider resize showdown — path()'s frozen pixel coords detach as the card narrows while shape()'s percentages reflow. text-wrap becomes a side-by-side default-vs-balance comparison on a keyboard-accessible width slider, so the orphan-stranding difference is visible and you can drag to the widths where balance clearly wins (kept the slider over a native resize handle for keyboard access).

Adds a third card to the shape() showcase: an S-wave clip whose depth is a registered @property, morphing on a pure-CSS toggle. Demonstrates the two things path() can't do — read custom properties and animate. Reduced-motion gated (snaps instead of morphing), decorative, discrete-toggle (not slider-driven) to stay within the performance rule.