### PR TITLE
fix: tether theme panel on wide screens, add back-to-nav skip links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,35 @@ fixes/features as they come in.
 - iOS zoom-in/zoom-out sometimes lands in a different section — needs the
   tester's video to reproduce; suspects: scroll anchoring vs sticky
   ghosts / scroll-driven timelines.
+- ~~Theme panel stranded top-right on very wide screens~~ — fixed: the
+  capped header detaches the toggle from the viewport edge; panel now
+  tethered to the toggle via anchor positioning (xl+), fallback kept.
+- ~~Hard to return to nav after jumping into long content (keyboard)~~ —
+  fixed: "Back to navigation" skip link ending each pillar (fixed-position
+  reveal, targets the nav landmark); pinned by e2e.
+- Space vs Enter on nav items "inconsistent" — NOT a bug: links scroll on
+  Space (native), summaries toggle on Space; mixing the two is what feels
+  inconsistent. Hijacking Space on links would break a web convention.
+  Leave as-is; explain to the reporter.
+- **BUG: filter breaks sidebar nav.** A sidebar link to a showcase the
+  active filter has hidden (`display: none`) jumps nowhere. Likely clean
+  fix: `.showcase:target { display: … }` so a direct link un-hides its
+  card regardless of the filter (pure CSS, no JS). Was flagged as a known
+  limitation when the filter shipped — now promote to a fix.
+- Keyboard shortcuts, done accessibly (feature, not the nav fix) — NOT
+  cmd/ctrl+N (browser-reserved). If built: safe keys, a `?` help overlay,
+  a 2.1.4 disable/remap mechanism, fire only when focus isn't in a field.
+  Teaches Character Key Shortcuts instead of violating it. The back-to-nav
+  skip links already cover the return-to-nav need, so this is additive.
+- Avatar + brief bio — put a face and a line of context on the site
+  (who made it, why). Supports the "personal / shareable" read testers
+  had. Content decision; where — hero corner, footer, or an About sliver.
+- Hero hover flourish — animate a strike-through onto "bolted on" in
+  "Built in, not bolted on" (pure CSS, reduced-motion gated). Reinforces
+  the thesis on interaction.
+- Big idea (someday): structure the whole site's flow around a real
+  physical object made digital — a skeuomorphic narrative spine. Open
+  design question; bring references before building.
 - "Motion that bows out on request" demo is a bit boring — rethink it
   (AnimationDemo). Make the reduced-motion contrast more visceral / the
   default motion more worth taming.

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,7 +80,7 @@
     </header>
 
     <div class="app-body">
-      <nav class="toc" aria-label="Sections">
+      <nav id="sections-nav" class="toc" tabindex="-1" aria-label="Sections">
         <p class="toc-heading">On this page</p>
         <ol class="toc-groups" role="list">
           <li v-for="group in toc" :key="group.id" class="toc-group">
@@ -185,6 +185,8 @@
           </p>
           <LegalMap />
         </section>
+
+        <a class="skip-link visually-hidden-focusable" href="#sections-nav">Back to navigation</a>
       </section>
 
       <section id="craft" class="pillar scrollspy-region" aria-labelledby="craft-title">
@@ -350,6 +352,8 @@
           </p>
           <LoadingStateDemo />
         </section>
+
+        <a class="skip-link visually-hidden-focusable" href="#sections-nav">Back to navigation</a>
       </section>
 
       <section id="showcase" class="pillar scrollspy-region" aria-labelledby="showcase-title">
@@ -407,6 +411,8 @@
             </div>
           </template>
         </div>
+
+        <a class="skip-link visually-hidden-focusable" href="#sections-nav">Back to navigation</a>
       </section>
 
       <section id="testing" class="pillar scrollspy-region" aria-labelledby="testing-title">
@@ -480,6 +486,8 @@
             assistive-tech experience stays quick.
           </p>
         </section>
+
+        <a class="skip-link visually-hidden-focusable" href="#sections-nav">Back to navigation</a>
       </section>
     </main>
     </div>

--- a/src/components/ThemeToggle/ThemeToggle.scss
+++ b/src/components/ThemeToggle/ThemeToggle.scss
@@ -4,6 +4,7 @@
   }
 
   .theme-toggle-trigger {
+    anchor-name: --theme-toggle;
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
@@ -34,6 +35,8 @@
   }
 
   .theme-panel {
+    /* Fallback for browsers without anchor positioning: pin below the header,
+       viewport-right. Superseded by the anchored rules below where supported. */
     position: fixed;
     inset: auto;
     inset-block-start: calc(var(--space-16) + var(--space-3));
@@ -52,6 +55,24 @@
 
     @include high-contrast {
       border-color: currentcolor;
+    }
+  }
+
+  /* Once the header hits its max width and centres, the toggle leaves the
+     viewport edge — a fixed corner position would strand the panel far from
+     it (the wide-screen bug). Tether it to the trigger instead (dogfoods
+     anchor positioning). Below the cap the viewport-corner fallback fits and
+     stays put, so this only engages from xl up. */
+  @supports (anchor-name: --a) {
+    @include from('xl') {
+      .theme-panel {
+        position-anchor: --theme-toggle;
+        inset: auto;
+        inset-block-start: anchor(bottom);
+        inset-inline-end: anchor(right);
+        margin-block-start: var(--space-2);
+        position-try-fallbacks: flip-block;
+      }
     }
   }
 

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -21,10 +21,12 @@
   }
 
 
-  /* Skip link — first focusable element in <body>, pointing at <main> (which
-     needs the matching id and tabindex="-1"). Pairs with -focusable above. */
+  /* Skip link — the "skip to main" first child of <body> and the "back to
+     navigation" links ending each pillar (both target an id + tabindex="-1").
+     Fixed, not absolute, so a link focused deep in the page still appears in
+     the viewport rather than at its container's top. Pairs with -focusable. */
   .skip-link {
-    position: absolute;
+    position: fixed;
     inset-block-start: var(--space-2);
     inset-inline-start: var(--space-2);
     z-index: 999;

--- a/tests/e2e/keyboard.spec.ts
+++ b/tests/e2e/keyboard.spec.ts
@@ -17,6 +17,23 @@ test.describe('keyboard & focus behaviour', () => {
     }
   })
 
+  test('each pillar offers a "back to navigation" escape hatch', async ({ page }) => {
+    await page.goto('/')
+
+    // One per pillar, so keyboard users deep in long content can return to the nav.
+    const backLinks = page.getByRole('link', { name: /back to navigation/i })
+    await expect(backLinks).toHaveCount(4)
+
+    const first = backLinks.first()
+    await first.focus()
+    await expect(first).toBeVisible() // revealed on focus, not permanently hidden
+    await first.press('Enter')
+
+    await expect
+      .poll(() => page.evaluate(() => document.activeElement?.id))
+      .toBe('sections-nav')
+  })
+
   test('native dialog traps focus and closes on Escape', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('button', { name: /open dialog/i }).click()


### PR DESCRIPTION
hree keyboard/wide-screen fixes from user feedback: (1) theme panel tethered to its toggle via anchor positioning on xl+ screens (was stranded in the viewport corner when the capped header centres); (2) "Back to navigation" skip links ending each pillar so keyboard users can return to the nav without shift-tabbing through long content — targets the nav landmark, fixed-position reveal, pinned by e2e; (3) verified the Space/Enter "inconsistency" is correct native link-vs-summary behavior and left it unchanged.