### PR TITLE
fix: derive ghost year and spinner from --color-text for theme-robust contrast

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,9 +43,11 @@ fixes/features as they come in.
   path()'s frozen coords visibly detach while shape() reflows.
 - ~~text-wrap demo interactive~~ — done: one block toggled in place via
   :has(), default vs balance+pretty.
-- Timeline ghost year too subtle in the dark default theme (fine in
-  light/sunset) — stroke-contrast tune; decorative, so keep it quiet, but
-  "didn't notice 2008" defeats the orientation purpose.
+- ~~Timeline ghost year too subtle in dark theme~~ & ~~loading spinner
+  low-contrast in some themes~~ — fixed together (Round 2c): both now
+  derive from `--color-text` (engine-guaranteed to contrast the bg)
+  instead of `--color-border` / `--color-primary`, which can wash out on
+  some seeds. Ghost stays quiet (24% text mix); spinner arc is full text.
 - iOS zoom-in/zoom-out sometimes lands in a different section — needs the
   tester's video to reproduce; suspects: scroll anchoring vs sticky
   ghosts / scroll-driven timelines.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1729,10 +1729,18 @@ const toc: TocGroup[] = [
   .spinner {
     inline-size: var(--space-8);
     block-size: var(--space-8);
-    border: 4px solid var(--color-border);
-    border-block-start-color: var(--color-primary);
+    /* Track + arc both derive from --color-text, which the theming engine
+       guarantees contrasts the background — --color-primary can wash out
+       against some seeds (e.g. the light amber preset). */
+    border: 4px solid color-mix(in oklab, var(--color-text) 20%, transparent);
+    border-block-start-color: var(--color-text);
     border-radius: var(--radius-full);
     animation: spin 1s linear infinite;
+
+    @include forced-colors {
+      border-color: CanvasText;
+      border-block-start-color: Highlight;
+    }
   }
 
   @keyframes spin {

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -59,7 +59,10 @@
     line-height: 1;
     letter-spacing: -0.04em;
     color: transparent;
-    -webkit-text-stroke: 1.5px var(--color-border);
+    /* A fixed fraction of the text colour, not --color-border: the border token
+       is calibrated against --color-bg and goes nearly invisible on the dark
+       default theme. This keeps the same quiet weight in every theme. */
+    -webkit-text-stroke: 1.5px color-mix(in oklab, var(--color-text) 24%, transparent);
 
     @include high-contrast {
       content: none;


### PR DESCRIPTION
Round 2c: the timeline ghost year and the motion-demo spinner both used tokens that aren't guaranteed to contrast the background (--color-border, --color-primary), so they washed out on some themes — the ghost invisible on dark, the spinner arc near-invisible on the light amber preset. Both now derive from --color-text (engine-guaranteed contrast): ghost stays quiet at a 24% mix, spinner arc goes full text with a faint track. Forced-colors treatment added to the spinner.