### PR TITLE
fix: reveal filtered-out showcase when linked to (:target in utilities layer)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,31 +61,28 @@ fixes/features as they come in.
   Space (native), summaries toggle on Space; mixing the two is what feels
   inconsistent. Hijacking Space on links would break a web convention.
   Leave as-is; explain to the reporter.
-- **BUG: filter breaks sidebar nav.** A sidebar link to a showcase the
-  active filter has hidden (`display: none`) jumps nowhere. Likely clean
-  fix: `.showcase:target { display: … }` so a direct link un-hides its
-  card regardless of the filter (pure CSS, no JS). Was flagged as a known
-  limitation when the filter shipped — now promote to a fix.
+- ~~BUG: filter breaks sidebar nav~~ — fixed (3a): `:target` reveal in the
+  utilities layer un-hides a linked-to card + its tier group, beating the
+  components-layer filter by layer order (pure CSS, no JS). Pinned by e2e.
 - Keyboard shortcuts, done accessibly (feature, not the nav fix) — NOT
   cmd/ctrl+N (browser-reserved). If built: safe keys, a `?` help overlay,
   a 2.1.4 disable/remap mechanism, fire only when focus isn't in a field.
   Teaches Character Key Shortcuts instead of violating it. The back-to-nav
   skip links already cover the return-to-nav need, so this is additive.
-- Avatar + brief bio — put a face and a line of context on the site
-  (who made it, why). Supports the "personal / shareable" read testers
-  had. Content decision; where — hero corner, footer, or an About sliver.
+- Avatar + brief bio — DECIDED (Thomas): a footer sliver (face, one line,
+  a link). Round 3c.
 - Hero hover flourish — animate a strike-through onto "bolted on" in
   "Built in, not bolted on" (pure CSS, reduced-motion gated). Reinforces
   the thesis on interaction.
 - Big idea (someday): structure the whole site's flow around a real
   physical object made digital — a skeuomorphic narrative spine. Open
   design question; bring references before building.
-- "Motion that bows out on request" demo is a bit boring — rethink it
-  (AnimationDemo). Make the reduced-motion contrast more visceral / the
-  default motion more worth taming.
-- Loading spinner (AppSpinner / loading-states demo) low-contrast in some
-  themes — the wheel can wash out against certain seeds. Give it a
-  theme-aware track/contrast treatment.
+- ~~"Motion that bows out on request" demo boring~~ & ~~"Targets that
+  survive touch and forced colors" demo boring~~ — done: both rebuilt as
+  interactive. Motion: three animations (spinner/progress/pulse) that all
+  freeze from one simulate-reduced-motion switch. Targets: a coarse-pointer
+  toggle grows hit areas 24→44px, and a forced-colors preview dissolves the
+  colour-only button while the bordered one survives.
 
 ### Watchlist (too early / conditional — revisit)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,9 +71,11 @@ fixes/features as they come in.
   skip links already cover the return-to-nav need, so this is additive.
 - Avatar + brief bio — DECIDED (Thomas): a footer sliver (face, one line,
   a link). Round 3c.
-- Hero hover flourish — animate a strike-through onto "bolted on" in
-  "Built in, not bolted on" (pure CSS, reduced-motion gated). Reinforces
-  the thesis on interaction.
+- ~~Hero hover flourish~~ — done (3b): a line draws across "bolted on" on
+  hover of the title. Pure CSS (scaleX on a pseudo-element), reduced-motion
+  gated (instant, no draw), can-hover only, forced-colors aware. The span
+  needed its own gradient clip — position:relative pulls it out of the
+  parent's background-clip:text.
 - Big idea (someday): structure the whole site's flow around a real
   physical object made digital — a skeuomorphic narrative spine. Open
   design question; bring references before building.

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@
           </span>
         </div>
 
-        <h1 class="hero-title">Built in, not bolted on</h1>
+        <h1 class="hero-title">Built in, not <span class="hero-strike">bolted on</span></h1>
         <p class="hero-lede">
           A hands-on look at how much of accessibility the modern web platform
           handles <em>natively</em> — with little to no JavaScript. It runs as
@@ -1386,6 +1386,52 @@ const toc: TocGroup[] = [
       background: none;
       -webkit-text-fill-color: CanvasText;
       color: CanvasText;
+    }
+  }
+
+  /* Hover flourish: a line draws across "bolted on", performing the thesis.
+     position:relative pulls the span out of the parent's background-clip:text,
+     so it needs its own gradient fill to keep rendering; the ::after line sits
+     in a solid colour over it. */
+  .hero-strike {
+    position: relative;
+    background: var(--gradient-accent);
+    /* stylelint-disable-next-line property-no-vendor-prefix -- Safari */
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+
+    @include forced-colors {
+      background: none;
+      -webkit-text-fill-color: CanvasText;
+    }
+  }
+
+  .hero-strike::after {
+    content: '';
+    position: absolute;
+    inset-inline: -0.04em;
+    inset-block-start: 51%;
+    block-size: 0.09em;
+    border-radius: 1em;
+    background-color: var(--color-text);
+    scale: 0 1;
+    transform-origin: left center;
+
+    @include forced-colors {
+      background-color: CanvasText;
+    }
+  }
+
+  @include can-hover {
+    .hero-title:hover .hero-strike::after {
+      scale: 1 1;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .hero-strike::after {
+      transition: scale var(--duration-normal) var(--easing-standard);
     }
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -273,12 +273,14 @@
         <section class="demo" aria-labelledby="craft-motion">
           <h3 id="craft-motion">Motion that bows out on request</h3>
           <p>
-            This spinner stops when the OS asks for reduced motion — handled
-            globally in <code>preferences.css</code> from a single source of
-            truth, so no component has to remember to opt in. The craft move is
-            making the accessible behaviour automatic rather than per-component.
+            Three independent animations, one preference. When the OS asks for
+            reduced motion, all of them still — handled globally in
+            <code>preferences.css</code> from a single source of truth, so no
+            component has to remember to opt in. Flip the switch to simulate the
+            preference (your real OS setting works too) and watch every one stop
+            at once.
           </p>
-          <div class="spinner" aria-hidden="true"></div>
+          <MotionDemo />
         </section>
 
         <section class="demo" aria-labelledby="craft-targets">
@@ -290,10 +292,7 @@
             background is replaced — a failure mode most buttons never account
             for.
           </p>
-          <div class="demo-row">
-            <AppButton variant="primary">Primary action</AppButton>
-            <AppButton variant="secondary">Secondary action</AppButton>
-          </div>
+          <TargetsDemo />
         </section>
 
         <section class="demo" aria-labelledby="craft-defensive">
@@ -565,6 +564,8 @@ import CriteriaTimeline from './criteria/CriteriaTimeline/CriteriaTimeline.vue'
 import ConformanceShift from './criteria/ConformanceShift/ConformanceShift.vue'
 import LegalMap from './criteria/LegalMap/LegalMap.vue'
 import LightDarkDemo from './craft/demos/LightDarkDemo.vue'
+import MotionDemo from './craft/demos/MotionDemo.vue'
+import TargetsDemo from './craft/demos/TargetsDemo.vue'
 import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
 import ContentStressDemo from './craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from './craft/demos/LoadingStateDemo.vue'
@@ -1724,29 +1725,6 @@ const toc: TocGroup[] = [
   .footer-copy {
     margin-inline-start: auto;
     color: var(--color-text-subtle);
-  }
-
-  .spinner {
-    inline-size: var(--space-8);
-    block-size: var(--space-8);
-    /* Track + arc both derive from --color-text, which the theming engine
-       guarantees contrasts the background — --color-primary can wash out
-       against some seeds (e.g. the light amber preset). */
-    border: 4px solid color-mix(in oklab, var(--color-text) 20%, transparent);
-    border-block-start-color: var(--color-text);
-    border-radius: var(--radius-full);
-    animation: spin 1s linear infinite;
-
-    @include forced-colors {
-      border-color: CanvasText;
-      border-block-start-color: Highlight;
-    }
-  }
-
-  @keyframes spin {
-    to {
-      rotate: 1turn;
-    }
   }
 }
 </style>

--- a/src/craft/demos/MotionDemo.vue
+++ b/src/craft/demos/MotionDemo.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="motion-demo" :class="{ 'is-rm': simulateRm }">
+    <label class="motion-sim">
+      <input v-model="simulateRm" type="checkbox" />
+      <span>Simulate: I prefer reduced motion</span>
+    </label>
+
+    <div class="motion-stage">
+      <div class="motion-item">
+        <div class="motion-spinner" aria-hidden="true"></div>
+        <p class="motion-item-label">Spinner</p>
+      </div>
+      <div class="motion-item">
+        <div class="motion-progress" aria-hidden="true"><span></span></div>
+        <p class="motion-item-label">Progress</p>
+      </div>
+      <div class="motion-item">
+        <div class="motion-pulse" aria-hidden="true"></div>
+        <p class="motion-item-label">Live pulse</p>
+      </div>
+    </div>
+
+    <p class="motion-readout" role="status">{{ readout }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+// Simulates the OS preference so the effect is visible without changing system
+// settings; the real prefers-reduced-motion media query drives it too.
+const simulateRm = ref(false)
+const readout = computed(() =>
+  simulateRm.value
+    ? 'Reduced motion — all three froze from one switch, no component opted in.'
+    : 'Motion on. Toggle the preference (or set it in your OS) to still it.',
+)
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .motion-demo {
+    /* One switch for every animation here: 0 = allowed, 1 = suppressed. The
+       real preference sets it globally (preferences.css); the checkbox
+       simulates that so the payoff is visible in-page. */
+    --rm: 0;
+
+    display: grid;
+    gap: var(--space-4);
+
+    @include reduced-motion {
+      --rm: 1;
+    }
+
+    &.is-rm {
+      --rm: 1;
+    }
+  }
+
+  .motion-sim {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .motion-stage {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
+    gap: var(--space-4);
+  }
+
+  .motion-item {
+    display: grid;
+    gap: var(--space-2);
+    justify-items: center;
+    align-content: start;
+    padding: var(--space-4) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-subtle);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .motion-item-label {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  /* Every duration is scaled by (1 - --rm): at rm:1 it collapses to 0, so the
+     animation holds its start frame — no per-element reduced-motion rule. */
+  .motion-spinner {
+    inline-size: var(--space-8);
+    block-size: var(--space-8);
+    border: 4px solid color-mix(in oklab, var(--color-text) 20%, transparent);
+    border-block-start-color: var(--color-text);
+    border-radius: var(--radius-full);
+    animation: motion-spin calc(1s * (1 - var(--rm))) linear infinite;
+
+    @include forced-colors {
+      border-color: CanvasText;
+      border-block-start-color: Highlight;
+    }
+  }
+
+  .motion-progress {
+    inline-size: 100%;
+    block-size: var(--space-2);
+    border-radius: var(--radius-full);
+    background-color: color-mix(in oklab, var(--color-text) 12%, transparent);
+    overflow: hidden;
+
+    span {
+      display: block;
+      block-size: 100%;
+      inline-size: 40%;
+      border-radius: inherit;
+      background-color: var(--color-primary);
+      animation: motion-progress calc(1.4s * (1 - var(--rm))) var(--easing-standard) infinite;
+    }
+  }
+
+  .motion-pulse {
+    inline-size: var(--space-6);
+    block-size: var(--space-6);
+    border-radius: var(--radius-full);
+    background-color: var(--color-primary);
+    animation: motion-pulse calc(1.6s * (1 - var(--rm))) var(--easing-standard) infinite;
+
+    @include forced-colors {
+      background-color: Highlight;
+    }
+  }
+
+  .motion-readout {
+    min-block-size: 2lh;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  @keyframes motion-spin {
+    to {
+      rotate: 1turn;
+    }
+  }
+
+  @keyframes motion-progress {
+    0% {
+      translate: -110% 0;
+    }
+
+    100% {
+      translate: 310% 0;
+    }
+  }
+
+  @keyframes motion-pulse {
+    0%,
+    100% {
+      scale: 0.7;
+      opacity: 0.5;
+    }
+
+    50% {
+      scale: 1;
+      opacity: 1;
+    }
+  }
+}
+</style>

--- a/src/craft/demos/TargetsDemo.vue
+++ b/src/craft/demos/TargetsDemo.vue
@@ -1,0 +1,228 @@
+<template>
+  <div class="targets-demo">
+    <section class="targets-panel" :class="{ 'is-touch': touch }">
+      <label class="targets-toggle">
+        <input v-model="touch" type="checkbox" />
+        <span>Simulate: coarse pointer (touch)</span>
+      </label>
+      <article class="targets-card">
+        <p class="targets-card-title">Weeknight pasta</p>
+        <p class="targets-card-meta">Dana Reeves · 12 min</p>
+        <div class="targets-actions" role="group" aria-label="Post actions">
+          <button
+            v-for="a in actions"
+            :key="a.label"
+            class="targets-action"
+            type="button"
+            :aria-label="a.label"
+          >
+            <svg class="targets-action-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path :d="a.d" />
+            </svg>
+          </button>
+        </div>
+      </article>
+      <p class="targets-readout" role="status">
+        Hit area: <strong>{{ touch ? '44' : '24' }}px</strong> —
+        {{ touch
+          ? 'coarse pointers get the roomier target via touch-primary(); the icons stay put, the tap area grows around them.'
+          : 'the AA floor (2.5.8) for a fine pointer. Simulate touch to see the tap targets grow.' }}
+      </p>
+    </section>
+
+    <section class="targets-panel" :class="{ 'is-forced': forced }">
+      <label class="targets-toggle">
+        <input v-model="forced" type="checkbox" />
+        <span>Preview: forced-colors mode</span>
+      </label>
+      <div class="targets-forced-row">
+        <button class="targets-fc targets-fc-fill" type="button">Colour only</button>
+        <button class="targets-fc targets-fc-border" type="button">Bordered</button>
+      </div>
+      <p class="targets-readout" role="status">
+        {{ forced
+          ? 'Backgrounds are replaced: the colour-only button lost its edges; the bordered one survives.'
+          : 'Both look fine now. Preview forced colours to see which one disappears.' }}
+      </p>
+      <p class="targets-fine-print">
+        A simulated preview — real forced-colors mode does this to every element
+        on the page, not just these two.
+      </p>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+// Simulate the pointer type and forced-colors mode so the payoffs are visible
+// in-page; the real (pointer: coarse) and forced-colors media queries drive
+// the shipped behaviour.
+const touch = ref(false)
+const forced = ref(false)
+
+const actions = [
+  { label: 'Like', d: 'M12 21 4.3 13.3a4.6 4.6 0 0 1 6.5-6.5l1.2 1.2 1.2-1.2a4.6 4.6 0 0 1 6.5 6.5Z' },
+  { label: 'Comment', d: 'M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2Z' },
+  { label: 'Share', d: 'M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7 M16 6l-4-4-4 4 M12 2v13' },
+  { label: 'Save', d: 'M19 21l-7-5-7 5V4a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1Z' },
+]
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .targets-demo {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+    gap: var(--space-4);
+  }
+
+  .targets-panel {
+    display: grid;
+    gap: var(--space-3);
+    align-content: start;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-subtle);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .targets-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .targets-card {
+    display: grid;
+    gap: 2px;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .targets-card-title {
+    font-weight: 600;
+  }
+
+  .targets-card-meta {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .targets-actions {
+    display: flex;
+    margin-block-start: var(--space-2);
+  }
+
+  .targets-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* 24px is the 2.5.8 AA floor for a fine pointer; touch bumps the tap area
+       to 44px, mirroring the touch-primary() mixin. The icon never resizes —
+       only the hittable padding around it grows. */
+    min-inline-size: 24px;
+    min-block-size: 24px;
+    border: none;
+    border-radius: var(--radius-full);
+    background: none;
+    color: var(--color-text-subtle);
+    cursor: pointer;
+    transition:
+      min-inline-size var(--duration-normal) var(--easing-standard),
+      min-block-size var(--duration-normal) var(--easing-standard);
+
+    @include can-hover {
+      &:hover {
+        color: var(--color-primary);
+      }
+    }
+  }
+
+  .targets-action-icon {
+    inline-size: 1.25rem;
+    block-size: 1.25rem;
+    fill: none;
+    stroke: currentcolor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .is-touch {
+    .targets-action {
+      min-inline-size: 44px;
+      min-block-size: 44px;
+    }
+  }
+
+  .targets-forced-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .targets-fc {
+    min-block-size: 44px;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    color: var(--color-primary-text);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  /* Relies on background colour alone — no border. */
+  .targets-fc-fill {
+    border: none;
+    background-color: var(--color-primary);
+  }
+
+  /* Same fill, but a border does the load-bearing work. */
+  .targets-fc-border {
+    border: 2px solid var(--color-primary-hover);
+    background-color: var(--color-primary);
+  }
+
+  /* Simulated forced colors: strip the custom fills to a neutral surface, as
+     the real mode does. The colour-only button now blends into the panel;
+     the bordered one keeps a visible outline. */
+  .is-forced {
+    /* Match the panel exactly, as the real mode collapses everything to one
+       surface: the colour-only button dissolves into it, edges and all. */
+    .targets-fc {
+      background-color: var(--color-bg-subtle);
+      color: var(--color-text);
+    }
+
+    .targets-fc-border {
+      border-color: var(--color-text);
+    }
+  }
+
+  .targets-readout {
+    min-block-size: 3lh;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .targets-fine-print {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+    opacity: 0.8;
+  }
+}
+</style>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -21,6 +21,16 @@
   }
 
 
+  /* A fragment link to a showcase the topic filter has hidden must still land:
+     :target reveals the card (and its tier group) regardless of the filter.
+     Works purely because utilities > components in the layer order — no
+     specificity battle, no JS to reset the filter. */
+  .showcase:target,
+  .showcase-group:has(.showcase:target) {
+    display: grid;
+  }
+
+
   /* Skip link — the "skip to main" first child of <body> and the "back to
      navigation" links ending each pillar (both target an id + tabindex="-1").
      Fixed, not absolute, so a link focused deep in the page still appears in

--- a/tests/e2e/keyboard.spec.ts
+++ b/tests/e2e/keyboard.spec.ts
@@ -89,4 +89,24 @@ test.describe('keyboard & focus behaviour', () => {
     await page.keyboard.press('ArrowRight')
     await expect(page.getByRole('radio', { name: 'Grid' })).toBeChecked()
   })
+
+  test('a link to a filtered-out showcase still reveals it (:target beats the filter)', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    // Filter to "forms" — the popover showcase (tagged interaction) is hidden.
+    // Set :checked directly; the CSS :has() filter reacts to the property, and
+    // it dodges a WebKit quirk clicking the custom-styled radio.
+    await page.locator('.showcase-filter input[value="forms"]').evaluate((el) => {
+      ;(el as HTMLInputElement).checked = true
+    })
+    const popover = page.locator('#showcase-popover')
+    await expect(popover).toBeHidden()
+
+    // A sidebar link navigates by fragment; the target must un-hide.
+    await page.evaluate(() => {
+      location.hash = '#showcase-popover'
+    })
+    await expect(popover).toBeVisible()
+  })
 })


### PR DESCRIPTION
Round 3a: a sidebar link to a showcase hidden by the active topic filter jumped nowhere (the card was display: none). Fixed with a .showcase:target reveal in the utilities layer, which un-hides the card and its tier group by beating the components-layer filter on layer order — pure CSS, no JS. Pinned by e2e (all engines). Known minor edge: a navigated-to card lingers if you then change the filter, until you navigate elsewhere.