### PR TITLE
feat: add per-showcase "View source" links to full demo source on GitHub

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,6 +86,13 @@ fixes/features as they come in.
   freeze from one simulate-reduced-motion switch. Targets: a coarse-pointer
   toggle grows hit areas 24→44px, and a forced-colors preview dissolves the
   colour-only button while the bordered one survives.
+- ~~"I'd like to see the code" (former colleague)~~ — done: every showcase now
+  carries an always-visible "View source" link (GitHub mark, opens in a new tab)
+  beside "Show the code", pointing at that demo's full folder on GitHub — the
+  snippet panel is only a portable excerpt. The URL is derived from the file
+  tree (import.meta.glob → component→folder map), so new demos get it for free.
+  The signal was worth acting on even though the reply read as a skim: code was
+  previously reachable only by opening each collapsed panel.
 
 ### Watchlist (too early / conditional — revisit)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -403,6 +403,7 @@
                   :snippet-html="item.snippetHtml"
                   :snippet-css="item.snippetCss"
                   :snippet-js="item.snippetJs"
+                  :source-href="item.sourceHref"
                 >
                   <component :is="item.component" v-bind="item.props" />
                 </ShowcaseFrame>

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.scss
@@ -90,6 +90,54 @@
     border-radius: var(--radius-md);
   }
 
+  /* Row holding the two ways to read the code: the inline "Show the code"
+     disclosure and an always-visible link to the full source on GitHub. Both
+     stay top-aligned so the link sits beside the summary as the panel expands. */
+  .showcase-code-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: start;
+    gap: var(--space-2) var(--space-4);
+  }
+
+  .showcase-code {
+    min-inline-size: 0; // let a wide code block scroll instead of stretching the row
+  }
+
+  /* The snippet panel is a portable excerpt; this links to the complete
+     component (template, styles, and the excerpt's source) on GitHub. */
+  .showcase-source {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-1);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text-subtle);
+    text-decoration: none;
+
+    @include can-hover {
+      transition: color var(--duration-fast) var(--easing-standard);
+
+      &:hover {
+        color: var(--color-primary);
+        text-decoration: underline;
+      }
+    }
+
+    &:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: 2px;
+      border-radius: var(--radius-sm);
+    }
+  }
+
+  .showcase-source-glyph {
+    inline-size: 1.15em;
+    block-size: 1.15em;
+    color: var(--color-primary);
+  }
+
   /* "Show the code" — a native <details>, so keyboard/SR behaviour and the
      expanded state come for free; styled as a button-like affordance. */
   .showcase-code-summary {

--- a/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
+++ b/src/showcases/ShowcaseFrame/ShowcaseFrame.vue
@@ -30,42 +30,61 @@
       <slot />
     </div>
 
-    <details v-if="snippetHtml || snippetCss || snippetJs" class="showcase-code">
-      <summary class="showcase-code-summary">
-        <svg
-          class="showcase-code-glyph"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="9 8 5 12 9 16" />
-          <polyline points="15 8 19 12 15 16" />
+    <div v-if="hasSnippet || sourceHref" class="showcase-code-actions">
+      <details v-if="hasSnippet" class="showcase-code">
+        <summary class="showcase-code-summary">
+          <svg
+            class="showcase-code-glyph"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="9 8 5 12 9 16" />
+            <polyline points="15 8 19 12 15 16" />
+          </svg>
+          <span class="showcase-code-label showcase-code-label-show">Show the code</span>
+          <span class="showcase-code-label showcase-code-label-hide">Hide the code</span>
+          <svg
+            class="showcase-code-chevron"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </summary>
+        <div class="showcase-code-body">
+          <CodeBlock v-if="snippetHtml" label="HTML" :code="snippetHtml" />
+          <CodeBlock v-if="snippetCss" label="CSS" :code="snippetCss" />
+          <CodeBlock v-if="snippetJs" label="JS" :code="snippetJs" />
+        </div>
+      </details>
+
+      <a
+        v-if="sourceHref"
+        class="showcase-source"
+        :href="sourceHref"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <svg class="showcase-source-glyph" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            fill="currentColor"
+            d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.51 11.51 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.91 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.015 2.898-.015 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+          />
         </svg>
-        <span class="showcase-code-label showcase-code-label-show">Show the code</span>
-        <span class="showcase-code-label showcase-code-label-hide">Hide the code</span>
-        <svg
-          class="showcase-code-chevron"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </summary>
-      <div class="showcase-code-body">
-        <CodeBlock v-if="snippetHtml" label="HTML" :code="snippetHtml" />
-        <CodeBlock v-if="snippetCss" label="CSS" :code="snippetCss" />
-        <CodeBlock v-if="snippetJs" label="JS" :code="snippetJs" />
-      </div>
-    </details>
+        <span>View source</span>
+        <span class="visually-hidden"> on GitHub (opens in a new tab)</span>
+      </a>
+    </div>
 
     <ul v-if="links.length" class="showcase-links">
       <li v-for="link in links" :key="link.href">
@@ -111,6 +130,8 @@ const props = withDefaults(
     snippetCss?: string
     /** Portable JS excerpt (raw string) — only for genuine JS-API features. */
     snippetJs?: string
+    /** GitHub URL to the demo's full source folder (the panel above is an excerpt). */
+    sourceHref?: string
   }>(),
   {
     supports: '',
@@ -120,11 +141,15 @@ const props = withDefaults(
     snippetHtml: '',
     snippetCss: '',
     snippetJs: '',
+    sourceHref: '',
   },
 )
 
 const headingId = useId()
 const headingTag = computed(() => `h${props.headingLevel}`)
+const hasSnippet = computed(() =>
+  Boolean(props.snippetHtml || props.snippetCss || props.snippetJs),
+)
 const supported = computed(() => {
   if (props.detect) return props.detect()
   return props.supports ? CSS.supports(props.supports) : true

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -133,6 +133,9 @@ export interface Showcase {
   snippetCss?: string
   /** Only for genuine JS-API features (Custom Highlight API, View Transitions). */
   snippetJs?: string
+  /** Link to this demo's full source folder on GitHub. The "Show the code"
+      panel is a portable excerpt; this points to the real, complete component. */
+  sourceHref?: string
 }
 
 const entries: Omit<Showcase, 'tier'>[] = [
@@ -832,4 +835,22 @@ const tierOf = (id: string): BaselineTier => {
   return 'limited-availability'
 }
 
-export const showcases: Showcase[] = entries.map((e) => ({ ...e, tier: tierOf(e.id) }))
+/* Map each demo component to its source folder on GitHub, derived from the file
+   tree so there's no per-entry path to keep in sync. The "Show the code" panel
+   only holds a portable excerpt — this is the full, real implementation. */
+const REPO_TREE = 'https://github.com/ThomasSweet/a11y-foundation/tree/main/'
+const demoModules = import.meta.glob<{ default: Component }>('./demos/*/*.vue', {
+  eager: true,
+})
+const sourceHrefByComponent = new Map<Component, string>()
+for (const [path, module] of Object.entries(demoModules)) {
+  // './demos/Foo/Foo.vue' -> 'src/showcases/demos/Foo'
+  const dir = path.replace(/^\.\//, 'src/showcases/').replace(/\/[^/]+$/, '')
+  sourceHrefByComponent.set(module.default, REPO_TREE + dir)
+}
+
+export const showcases: Showcase[] = entries.map((e) => ({
+  ...e,
+  tier: tierOf(e.id),
+  sourceHref: sourceHrefByComponent.get(e.component),
+}))


### PR DESCRIPTION
Adds an always-visible "View source" link to every showcase card, beside "Show the code", linking to that demo's full source folder on GitHub. The "Show the code" panel only holds a portable excerpt, so this answers the recurring "where's the actual code?" instinct — previously the snippets were reachable only by expanding each collapsed panel. The GitHub URL is derived from the file tree via import.meta.glob (component→folder map), so all 29 cards are covered and new demos get the link automatically with nothing to maintain. Reduced-motion/forced-colors safe, accessible name spells out "opens in a new tab"; typecheck, stylelint, 38 unit and 27 e2e (axe across Chromium/Firefox/WebKit) all green. Prompted by post-launch feedback (logged in ROADMAP).