### PR TITLE
feat: pair each craft demo with a bad→good code comparison

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -96,6 +96,25 @@ fixes/features as they come in.
   "Show the code" toggle from a muted grey pill to a filled primary button
   (mirrors AppButton --primary, so the label colour stays contrast-safe on every
   theme), so skimmers actually notice the code is there.
+- ~~Code in the Craft section~~ — done: a reusable `CodeCompare` pairs each craft
+  demo with a short "common mistake → the craft" snippet (reuses CodeBlock, and
+  each mirrors that demo's real CSS/HTML so it can't drift). Shipped on 7 demos
+  (validation, dialog, motion, targets, defensive, content-stress, loading);
+  light-dark was skipped because it already shows both code blocks inline. The
+  "mistake" side has its Copy button suppressed (new `copyable` flag on CodeBlock)
+  — no point one-click-copying the anti-pattern. Bad→good distinction rides on
+  shape (✕/✓) + text, not colour alone. Snippets live in `src/craft/snippets.ts`.
+  The optional "emerging" third act is deferred to demos where a real successor
+  exists. Directly answers the "avoid it from happening" feedback.
+- Site-wide flow / length restructure (open, big) — sections run long (Craft most
+  of all, now more so with the code comparisons). Not a per-section trim: rethink
+  the whole narrative flow, likely splitting the pillars onto their own
+  pages/routes so each breathes instead of competing for one scroll. Parked
+  deliberately until it's tackled as its own effort; once sections have their own
+  pages, keeping any single section minimal matters far less. Candidate to fold in
+  then: per-topic "reference" links (MDN/spec) on the craft demos, like the
+  showcase cards already carry — deferred now to avoid adding weight to an
+  already-long section.
 
 ### Watchlist (too early / conditional — revisit)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -233,6 +233,7 @@
               hint="Optional — include a domain, e.g. name@example.com."
             />
           </div>
+          <CodeCompare v-bind="craftSnippets.validation" />
         </section>
 
         <section class="demo" aria-labelledby="craft-light-dark">
@@ -268,6 +269,7 @@
               stays inside while the dialog is open.
             </p>
           </AppDialog>
+          <CodeCompare v-bind="craftSnippets.dialog" />
         </section>
 
         <section class="demo" aria-labelledby="craft-motion">
@@ -281,6 +283,7 @@
             at once.
           </p>
           <MotionDemo />
+          <CodeCompare v-bind="craftSnippets.motion" />
         </section>
 
         <section class="demo" aria-labelledby="craft-targets">
@@ -293,6 +296,7 @@
             for.
           </p>
           <TargetsDemo />
+          <CodeCompare v-bind="craftSnippets.targets" />
         </section>
 
         <section class="demo" aria-labelledby="craft-defensive">
@@ -313,6 +317,7 @@
             it the hard way during QA, courtesy of an iOS WebKit quirk.)
           </p>
           <DefensiveCssDemo />
+          <CodeCompare v-bind="craftSnippets.defensive" />
         </section>
 
         <section class="demo" aria-labelledby="craft-content-stress">
@@ -330,6 +335,7 @@
             instead of a designer's optimism.
           </p>
           <ContentStressDemo />
+          <CodeCompare v-bind="craftSnippets.contentStress" />
         </section>
 
         <section class="demo" aria-labelledby="craft-loading">
@@ -340,9 +346,9 @@
             are semantic-free <code>div</code>s — a screen reader finds an
             empty region with no hint that anything is happening. The craft
             move costs two attributes: <code>aria-busy="true"</code> marks the
-            region as loading (and asks assistive tech to hold announcements
-            until it settles), and one visually-hidden line says what's
-            coming. A live region is usually the <em>wrong</em> tool here — on
+            region as loading (a state you clear once it settles), and one
+            visually-hidden line says what's coming — the part a screen reader
+            actually reads. A live region is usually the <em>wrong</em> tool here — on
             a fast connection the "loading" announcement lands after the
             content it was warning about. And size placeholders to the content
             they stand in for: a skeleton that shifts the page when real
@@ -350,6 +356,7 @@
             CLS (Cumulative Layout Shift) measures.
           </p>
           <LoadingStateDemo />
+          <CodeCompare v-bind="craftSnippets.loading" />
         </section>
 
         <a class="skip-link visually-hidden-focusable" href="#sections-nav">Back to navigation</a>
@@ -601,6 +608,8 @@ import TargetsDemo from './craft/demos/TargetsDemo.vue'
 import DefensiveCssDemo from './craft/demos/DefensiveCssDemo.vue'
 import ContentStressDemo from './craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from './craft/demos/LoadingStateDemo.vue'
+import CodeCompare from './craft/CodeCompare/CodeCompare.vue'
+import { craftSnippets } from './craft/snippets'
 import TestingLayers from './testing/TestingLayers/TestingLayers.vue'
 import AuditStylesheet from './testing/AuditStylesheet/AuditStylesheet.vue'
 import CoverageMatrix from './testing/CoverageMatrix/CoverageMatrix.vue'

--- a/src/craft/CodeCompare/CodeCompare.scss
+++ b/src/craft/CodeCompare/CodeCompare.scss
@@ -10,6 +10,16 @@
     display: grid;
     gap: var(--space-2);
     min-inline-size: 0; // let a wide snippet scroll instead of stretching the grid
+
+    /* Shape carries the mistake/craft distinction (cross vs check), so it
+       survives forced-colors and colour blindness; the tint just reinforces. */
+    &--mistake .code-compare-icon {
+      color: var(--color-error);
+    }
+
+    &--craft .code-compare-icon {
+      color: var(--color-success);
+    }
   }
 
   .code-compare-label {
@@ -20,19 +30,9 @@
     font-weight: 600;
   }
 
-  /* Shape carries the mistake/craft distinction (cross vs check) so it survives
-     forced-colors and colour blindness; the tint is redundant reinforcement. */
   .code-compare-icon {
     flex: none;
     inline-size: 1.15em;
     block-size: 1.15em;
-  }
-
-  .code-compare-item--mistake .code-compare-icon {
-    color: var(--color-error);
-  }
-
-  .code-compare-item--craft .code-compare-icon {
-    color: var(--color-success);
   }
 }

--- a/src/craft/CodeCompare/CodeCompare.scss
+++ b/src/craft/CodeCompare/CodeCompare.scss
@@ -1,0 +1,38 @@
+/* Library mixins are injected via Vite's additionalData, so no @use here. */
+@layer components {
+  .code-compare {
+    display: grid;
+    gap: var(--space-4);
+    min-inline-size: 0;
+  }
+
+  .code-compare-item {
+    display: grid;
+    gap: var(--space-2);
+    min-inline-size: 0; // let a wide snippet scroll instead of stretching the grid
+  }
+
+  .code-compare-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  /* Shape carries the mistake/craft distinction (cross vs check) so it survives
+     forced-colors and colour blindness; the tint is redundant reinforcement. */
+  .code-compare-icon {
+    flex: none;
+    inline-size: 1.15em;
+    block-size: 1.15em;
+  }
+
+  .code-compare-item--mistake .code-compare-icon {
+    color: var(--color-error);
+  }
+
+  .code-compare-item--craft .code-compare-icon {
+    color: var(--color-success);
+  }
+}

--- a/src/craft/CodeCompare/CodeCompare.vue
+++ b/src/craft/CodeCompare/CodeCompare.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="code-compare">
+    <div
+      class="code-compare-item code-compare-item--mistake"
+      role="group"
+      :aria-labelledby="mistakeId"
+    >
+      <p :id="mistakeId" class="code-compare-label">
+        <svg
+          class="code-compare-icon"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+        <span>{{ mistakeLabel }}</span>
+      </p>
+      <CodeBlock :label="language" :code="mistake" :copyable="false" />
+    </div>
+
+    <div
+      class="code-compare-item code-compare-item--craft"
+      role="group"
+      :aria-labelledby="craftId"
+    >
+      <p :id="craftId" class="code-compare-label">
+        <svg
+          class="code-compare-icon"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        <span>{{ craftLabel }}</span>
+      </p>
+      <CodeBlock :label="language" :code="craft" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue'
+import CodeBlock from '../../showcases/CodeBlock/CodeBlock.vue'
+
+withDefaults(
+  defineProps<{
+    /** Language label handed to CodeBlock: 'CSS' | 'HTML' | 'JS'. */
+    language: string
+    /** The inaccessible pattern, shown first. */
+    mistake: string
+    /** The accessible pattern that replaces it. */
+    craft: string
+    mistakeLabel?: string
+    craftLabel?: string
+  }>(),
+  {
+    mistakeLabel: 'Common mistake',
+    craftLabel: 'The craft',
+  },
+)
+
+// Each side is a labelled group so the two same-language "Copy" buttons and
+// code panels aren't indistinguishable to a screen reader navigating them.
+const mistakeId = useId()
+const craftId = useId()
+</script>
+
+<style scoped lang="scss" src="./CodeCompare.scss"></style>

--- a/src/craft/snippets.ts
+++ b/src/craft/snippets.ts
@@ -1,0 +1,132 @@
+/**
+ * Bad→good code pairs shown beneath each craft demo (see CodeCompare). Each
+ * mirrors the real CSS/HTML of the component it sits under, so the teaching
+ * snippet can't drift from what the demo actually does. Spread onto CodeCompare
+ * with v-bind — the object shape is exactly its props.
+ */
+export interface CraftCompareSnippet {
+  language: 'CSS' | 'HTML'
+  mistake: string
+  craft: string
+}
+
+export const craftSnippets = {
+  // Mirrors TextField.scss — the only diff is the pseudo-class and the cue.
+  validation: {
+    language: 'CSS',
+    mistake: `/* :invalid matches immediately — a required field is
+   "invalid" while empty, so it flags before any input. */
+input:invalid {
+  border-color: red;
+}`,
+    craft: `/* :user-invalid waits for interaction, so pristine
+   fields stay neutral. Thicker border = non-colour cue. */
+input:user-invalid {
+  border-color: var(--color-error);
+  border-width: 2px;
+}`,
+  },
+
+  // Mirrors AppDialog — native <dialog> + showModal().
+  dialog: {
+    language: 'HTML',
+    mistake: `<!-- A div "dialog": now hand-write focus trapping,
+     Esc-to-close, an inert background, scroll locking… -->
+<div class="modal" role="dialog" aria-modal="true">
+  …
+</div>`,
+    craft: `<!-- dialog.showModal() gives focus trapping, Esc, an
+     inert background and top-layer stacking, all free. -->
+<dialog class="modal">
+  …
+</dialog>`,
+  },
+
+  // Mirrors MotionDemo — one variable stills every animation at once.
+  motion: {
+    language: 'CSS',
+    mistake: `/* Spins for everyone, including someone who asked
+   their OS for reduced motion. */
+.spinner {
+  animation: spin 1s linear infinite;
+}`,
+    craft: `/* Scale the duration by one variable that flips to 1
+   under prefers-reduced-motion (set once, globally),
+   so nothing here has to opt in. */
+.spinner {
+  animation: spin calc(1s * (1 - var(--rm))) linear infinite;
+}`,
+  },
+
+  // Mirrors TargetsDemo — .targets-fc-fill vs .targets-fc-border.
+  targets: {
+    language: 'CSS',
+    mistake: `/* Background alone marks this button. In forced-colors
+   mode the fill is replaced and its edges vanish. */
+.button {
+  border: none;
+  background-color: var(--color-primary);
+}`,
+    craft: `/* A border does load-bearing work, so the button keeps
+   a visible edge when the background is stripped. */
+.button {
+  border: 2px solid var(--color-primary-hover);
+  background-color: var(--color-primary);
+}`,
+  },
+
+  // Mirrors DefensiveCssDemo — the two guards that contain runaway content.
+  defensive: {
+    language: 'CSS',
+    mistake: `/* A grid item's automatic minimum is its min-content
+   size, so one unbreakable URL forces the column past
+   the viewport — a 1.4.10 Reflow failure. */
+.card-body {
+  display: grid;
+}`,
+    craft: `/* Two guards: let the column shrink below its content,
+   and give the unbreakable line a local scroll. */
+.card-body {
+  display: grid;
+  min-inline-size: 0;
+}
+.url {
+  overflow-x: auto;
+}`,
+  },
+
+  // Mirrors ContentStressDemo — logical properties that follow dir/lang.
+  contentStress: {
+    language: 'CSS',
+    mistake: `/* Physical edges don't follow writing direction — in
+   an RTL layout the accent lands on the wrong side. */
+.card {
+  border-left: 4px solid var(--color-primary);
+  padding-left: 1rem;
+}`,
+    craft: `/* Logical properties flow with dir/lang, so one rule
+   mirrors correctly for LTR and RTL alike. */
+.card {
+  border-inline-start: 4px solid var(--color-primary);
+  padding-inline-start: 1rem;
+}`,
+  },
+
+  // Mirrors LoadingStateDemo — aria-busy + one hidden line.
+  loading: {
+    language: 'HTML',
+    mistake: `<!-- Skeleton divs only: a screen reader finds an empty
+     region with no hint that anything is loading. -->
+<div class="card">
+  <div class="skeleton-row"></div>
+  <div class="skeleton-row"></div>
+</div>`,
+    craft: `<!-- aria-busy flags the loading state (cleared when the
+     content lands); the skeleton is aria-hidden, so this
+     hidden line is what a screen reader actually reads. -->
+<div class="card" aria-busy="true">
+  <span class="visually-hidden">Loading recent activity…</span>
+  <div class="skeleton-row" aria-hidden="true"></div>
+</div>`,
+  },
+} satisfies Record<string, CraftCompareSnippet>

--- a/src/showcases/CodeBlock/CodeBlock.vue
+++ b/src/showcases/CodeBlock/CodeBlock.vue
@@ -3,6 +3,7 @@
     <figcaption class="code-block-bar">
       <span class="code-block-lang">{{ label }}</span>
       <button
+        v-if="copyable"
         type="button"
         class="code-block-copy"
         :aria-label="`Copy ${label} snippet to clipboard`"
@@ -17,19 +18,25 @@
     <pre class="code-block-pre" tabindex="0"><code v-html="highlighted" /></pre>
 
     <!-- Announces the copy result to screen readers without moving focus. -->
-    <span role="status" class="visually-hidden">{{ status }}</span>
+    <span v-if="copyable" role="status" class="visually-hidden">{{ status }}</span>
   </figure>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
-const props = defineProps<{
-  /** Raw snippet text, rendered verbatim. */
-  code: string
-  /** Short language label shown in the bar and used for announcements. */
-  label: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    /** Raw snippet text, rendered verbatim. */
+    code: string
+    /** Short language label shown in the bar and used for announcements. */
+    label: string
+    /** Show the copy button. Off for code we don't want copied — e.g. the
+        "before" side of a bad→good comparison. */
+    copyable?: boolean
+  }>(),
+  { copyable: true },
+)
 
 const trimmed = computed(() => props.code.replace(/\s+$/, ''))
 


### PR DESCRIPTION
New CodeCompare component shows a "common mistake → the craft" snippet under 7 craft demos, each mirroring the demo's real CSS/HTML; snippets live in src/craft/snippets.ts. Adds an opt-out `copyable` flag to CodeBlock so the anti-pattern side has no Copy button. light-dark is skipped — it already shows its code inline.