### PR TITLE
feat: add reading-flow showcase — focus order follows the visual layout

### DIFF
--- a/scripts/gen-baseline.mjs
+++ b/scripts/gen-baseline.mjs
@@ -46,6 +46,7 @@ const SHOWCASE_FEATURES = {
   'dialog-polish': 'dialog-closedby',
   'interest-invokers': 'interest-invokers',
   'view-transitions': 'view-transitions',
+  'reading-flow': 'reading-flow',
 }
 
 const BROWSERS = ['chrome', 'edge', 'firefox', 'safari']

--- a/src/showcases/baseline-data.json
+++ b/src/showcases/baseline-data.json
@@ -375,5 +375,18 @@
       "firefox": "144",
       "safari": "18"
     }
+  },
+  "reading-flow": {
+    "feature": "reading-flow",
+    "name": "reading-flow",
+    "baseline": false,
+    "lowDate": null,
+    "highDate": null,
+    "support": {
+      "chrome": "137",
+      "edge": "137",
+      "firefox": null,
+      "safari": null
+    }
   }
 }

--- a/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.snippet.css
+++ b/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.snippet.css
@@ -1,0 +1,18 @@
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+/* Visual promotion — the DOM stays chronological. */
+.featured {
+  order: -1;
+}
+
+/* Without this, Tab follows the DOM: 1 → 2 → 3 → jump back to 4.
+   With it, sequential focus (and assistive-tech reading order)
+   follows the visual arrangement: 4 → 1 → 2 → 3. */
+@supports (reading-flow: flex-visual) {
+  .gallery {
+    reading-flow: flex-visual;
+  }
+}

--- a/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.snippet.html
+++ b/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.snippet.html
@@ -1,0 +1,6 @@
+<ul class="gallery">
+  <li><button>Update 1</button></li>
+  <li><button>Update 2</button></li>
+  <li><button>Update 3</button></li>
+  <li class="featured"><button>Update 4</button></li>
+</ul>

--- a/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.vue
+++ b/src/showcases/demos/ReadingFlowDemo/ReadingFlowDemo.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="reading-flow-demo">
+    <p class="reading-flow-caption">
+      The gallery is chronological in the DOM, but <code>order: -1</code>
+      promotes the featured card to the front — the classic focus-order trap.
+      <kbd>Tab</kbd> through the cards: without the fix, focus walks the DOM
+      (1, 2, 3, then a jump back to 4). Toggle it and focus follows the layout
+      you actually see.
+    </p>
+
+    <label class="reading-flow-toggle">
+      <input type="checkbox" />
+      Fix the order with <code>reading-flow: flex-visual</code>
+    </label>
+
+    <ul class="reading-flow-gallery">
+      <li v-for="n in 4" :key="n" class="reading-flow-item">
+        <button type="button" class="reading-flow-card">
+          <span class="reading-flow-card-num" aria-hidden="true">{{ n }}</span>
+          Update {{ n }}
+          <span v-if="n === 4" class="reading-flow-card-chip">featured</span>
+        </button>
+      </li>
+    </ul>
+
+    <p class="reading-flow-note">
+      <strong>Why it matters:</strong> visual reordering with
+      <code>order</code>, <code>row-reverse</code>, or grid placement leaves
+      keyboard focus and screen-reader order stuck on the DOM — a Focus Order
+      (2.4.3) and Meaningful Sequence (1.3.2) failure that used to mean
+      restructuring your markup. <code>reading-flow</code> re-syncs them in one
+      declaration; <code>reading-order</code> handles per-item exceptions.
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@layer components {
+  .reading-flow-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .reading-flow-caption,
+  .reading-flow-note {
+    max-inline-size: 65ch;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .reading-flow-note {
+    padding: var(--space-3) var(--space-4);
+    border-inline-start: 3px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+
+    strong {
+      color: var(--color-text);
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .reading-flow-toggle {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .reading-flow-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .reading-flow-item:last-child {
+    order: -1;
+
+    .reading-flow-card {
+      border-color: var(--color-primary);
+    }
+  }
+
+  @supports (reading-flow: flex-visual) {
+    .reading-flow-demo:has(.reading-flow-toggle input:checked) .reading-flow-gallery {
+      /* stylelint-disable-next-line property-no-unknown -- Chrome-only, linter lags */
+      reading-flow: flex-visual;
+    }
+  }
+
+  .reading-flow-card {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-1);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    cursor: pointer;
+
+    &:focus-visible {
+      background-color: var(--color-bg-subtle);
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .reading-flow-card-num {
+    font-size: var(--text-xl);
+    font-weight: 800;
+    color: var(--color-primary);
+  }
+
+  .reading-flow-card-chip {
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-primary);
+    font-weight: 700;
+    color: var(--color-primary-text);
+  }
+}
+</style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -94,6 +94,9 @@ import interestSnippetHtml from './demos/InterestInvokerDemo/InterestInvokerDemo
 import interestSnippetCss from './demos/InterestInvokerDemo/InterestInvokerDemo.snippet.css?raw'
 import viewTransitionSnippetCss from './demos/ViewTransitionDemo/ViewTransitionDemo.snippet.css?raw'
 import viewTransitionSnippetJs from './demos/ViewTransitionDemo/ViewTransitionDemo.snippet.js?raw'
+import ReadingFlowDemo from './demos/ReadingFlowDemo/ReadingFlowDemo.vue'
+import readingFlowSnippetHtml from './demos/ReadingFlowDemo/ReadingFlowDemo.snippet.html?raw'
+import readingFlowSnippetCss from './demos/ReadingFlowDemo/ReadingFlowDemo.snippet.css?raw'
 
 /** Per-showcase Baseline status, generated into baseline-data.json by
     scripts/gen-baseline.mjs from the web-features package (build-time — the
@@ -823,9 +826,34 @@ const entries: Omit<Showcase, 'tier'>[] = [
     snippetCss: viewTransitionSnippetCss,
     snippetJs: viewTransitionSnippetJs,
   },
+  {
+    id: 'reading-flow',
+    title: 'reading-flow: flex-visual',
+    supports: 'reading-flow: flex-visual',
+    summary:
+      'order, row-reverse, and grid placement move things visually while ' +
+      'keyboard focus and screen-reader order stay stuck on the DOM — the ' +
+      'classic focus-order trap. reading-flow re-syncs sequential focus and ' +
+      'reading order with the visual arrangement in one declaration, pure ' +
+      'CSS; reading-order handles per-item exceptions. Tab through the ' +
+      'gallery with the fix off, then on.',
+    links: [
+      {
+        label: 'MDN: reading-flow',
+        href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/reading-flow',
+      },
+    ],
+    payoff:
+      'Focus and screen-reader order follow the layout users actually see — visual reordering stops breaking Focus Order (2.4.3) and Meaningful Sequence (1.3.2).',
+    tags: ['layout', 'interaction'],
+    component: ReadingFlowDemo,
+    snippetHtml: readingFlowSnippetHtml,
+    snippetCss: readingFlowSnippetCss,
+  },
 
   // Further candidates: media state pseudo-classes (custom player),
-  // anchor-positioned tooltips, customizable <select>.
+  // ::details-content + interpolate-size (animated native disclosure),
+  // text-box trim.
 ]
 
 const tierOf = (id: string): BaselineTier => {

--- a/tests/e2e/keyboard.spec.ts
+++ b/tests/e2e/keyboard.spec.ts
@@ -109,4 +109,38 @@ test.describe('keyboard & focus behaviour', () => {
     })
     await expect(popover).toBeVisible()
   })
+
+  test('reading-flow re-syncs tab order with the visual order (when supported)', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    const supported = await page.evaluate(() => CSS.supports('reading-flow: flex-visual'))
+    test.skip(!supported, 'reading-flow not implemented in this engine')
+
+    const toggle = page.locator('.reading-flow-toggle input')
+    await toggle.scrollIntoViewIfNeeded()
+
+    // Tab from the toggle through all four cards, collecting their numbers.
+    const tabbedOrder = async () => {
+      await toggle.focus()
+      let order = ''
+      for (let i = 0; i < 4; i++) {
+        await page.keyboard.press('Tab')
+        order += await page.evaluate(
+          () => document.activeElement?.textContent?.trim().charAt(0) ?? '?',
+        )
+      }
+      return order
+    }
+
+    // Unfixed: focus walks the DOM even though card 4 is visually first.
+    expect(await tabbedOrder()).toBe('1234')
+
+    // Set :checked directly, matching the filter test's WebKit-proof approach.
+    await toggle.evaluate((el) => {
+      ;(el as HTMLInputElement).checked = true
+    })
+    expect(await tabbedOrder()).toBe('4123')
+  })
 })


### PR DESCRIPTION
order: -1 promotes a featured card while the DOM stays chronological, the classic Focus Order (2.4.3) / Meaningful Sequence (1.3.2) trap. A pure-CSS toggle applies reading-flow: flex-visual so sequential focus and AT reading order re-sync with the layout. Chrome 137+, limited tier; e2e pins tab order 1234 -> 4123, skipping engines without support.