### PR TITLE
feat: add ::details-content showcase — the accordion excuse, removed

### DIFF
--- a/scripts/gen-baseline.mjs
+++ b/scripts/gen-baseline.mjs
@@ -47,6 +47,7 @@ const SHOWCASE_FEATURES = {
   'interest-invokers': 'interest-invokers',
   'view-transitions': 'view-transitions',
   'reading-flow': 'reading-flow',
+  'details-content': 'details-content',
 }
 
 const BROWSERS = ['chrome', 'edge', 'firefox', 'safari']

--- a/src/showcases/baseline-data.json
+++ b/src/showcases/baseline-data.json
@@ -388,5 +388,18 @@
       "firefox": null,
       "safari": null
     }
+  },
+  "details-content": {
+    "feature": "details-content",
+    "name": "::details-content",
+    "baseline": "low",
+    "lowDate": "2025-09-16",
+    "highDate": null,
+    "support": {
+      "chrome": "131",
+      "edge": "131",
+      "firefox": "143",
+      "safari": "18.4"
+    }
   }
 }

--- a/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.snippet.css
+++ b/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.snippet.css
@@ -1,0 +1,28 @@
+/* Style the browser's own content region; allow-discrete keeps the
+   content rendered until the closing fade finishes. */
+details::details-content {
+  opacity: 0;
+  block-size: 0;
+  overflow-y: clip;
+  transition:
+    content-visibility 0.25s allow-discrete,
+    opacity 0.25s,
+    block-size 0.25s;
+}
+
+details[open]::details-content {
+  opacity: 1;
+  block-size: auto;
+}
+
+/* Where supported, block-size animates to the real auto height;
+   elsewhere the content still fades. */
+details {
+  interpolate-size: allow-keywords;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  details::details-content {
+    transition: none;
+  }
+}

--- a/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.snippet.html
+++ b/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.snippet.html
@@ -1,0 +1,4 @@
+<details>
+  <summary>Does an accordion need JavaScript?</summary>
+  <p>Not anymore — this is a native details element.</p>
+</details>

--- a/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.vue
+++ b/src/showcases/demos/DetailsContentDemo/DetailsContentDemo.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="details-demo">
+    <p class="details-demo-caption">
+      A native <code>&lt;details&gt;</code> accordion with the one thing it
+      always lacked: a smooth open. <code>::details-content</code> styles the
+      browser's own content region; <code>interpolate-size</code> lets it glide
+      to its real <code>auto</code> height. Open one — the answers explain
+      themselves.
+    </p>
+
+    <div class="details-demo-list">
+      <details class="details-demo-item">
+        <summary class="details-demo-summary">Does an accordion need JavaScript?</summary>
+        <p class="details-demo-body">
+          Not anymore. This is a native <code>&lt;details&gt;</code> element:
+          the summary is a real disclosure button, screen readers announce
+          expanded and collapsed, and the keyboard works — all before a single
+          line of script.
+        </p>
+      </details>
+
+      <details class="details-demo-item">
+        <summary class="details-demo-summary">How does the smooth opening work?</summary>
+        <p class="details-demo-body">
+          <code>::details-content</code> targets the content region the browser
+          already renders, so it can transition opacity and block-size — with
+          <code>allow-discrete</code> holding <code>content-visibility</code>
+          until the close finishes. <code>interpolate-size: allow-keywords</code>
+          makes <code>auto</code> a real animation target. Browsers without it
+          fade; browsers without either simply open instantly. Never broken.
+        </p>
+      </details>
+
+      <details class="details-demo-item">
+        <summary class="details-demo-summary">And under reduced motion?</summary>
+        <p class="details-demo-body">
+          No animation at all — the transition is removed behind the
+          preference's media query, and the disclosure works exactly the same.
+          Motion is the enhancement here, never the mechanism.
+        </p>
+      </details>
+    </div>
+
+    <p class="details-demo-note">
+      <strong>Why it matters:</strong> a JS accordion has to re-implement what
+      <code>&lt;details&gt;</code> gives away free — button semantics, the
+      announced expanded state, keyboard support. The animation was the last
+      excuse to rebuild it, and this removes the excuse.
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@layer components {
+  .details-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .details-demo-caption,
+  .details-demo-note {
+    max-inline-size: 65ch;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .details-demo-note {
+    padding: var(--space-3) var(--space-4);
+    border-inline-start: 3px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-subtle);
+
+    strong {
+      color: var(--color-text);
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .details-demo-list {
+    display: grid;
+    gap: var(--space-2);
+
+    /* Inherited — lets every item's block-size animate to auto (Chrome). */
+    @supports (interpolate-size: allow-keywords) {
+      interpolate-size: allow-keywords;
+    }
+  }
+
+  .details-demo-item {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .details-demo-summary {
+    padding: var(--space-3) var(--space-4);
+    font-weight: 600;
+    cursor: pointer;
+
+    &::marker {
+      color: var(--color-primary);
+    }
+  }
+
+  /* allow-discrete holds content-visibility until the closing fade finishes.
+     The global reduced-motion kill switch only reaches *::before/::after, so
+     this pseudo-element gates itself. */
+  .details-demo-item::details-content {
+    opacity: 0;
+    block-size: 0;
+    overflow-y: clip;
+    transition:
+      content-visibility var(--duration-normal) allow-discrete,
+      opacity var(--duration-normal),
+      block-size var(--duration-normal);
+
+    @include reduced-motion {
+      transition: none;
+    }
+  }
+
+  .details-demo-item[open]::details-content {
+    opacity: 1;
+    block-size: auto;
+  }
+
+  .details-demo-body {
+    max-inline-size: 65ch;
+    margin: 0;
+    padding: 0 var(--space-4) var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -97,6 +97,9 @@ import viewTransitionSnippetJs from './demos/ViewTransitionDemo/ViewTransitionDe
 import ReadingFlowDemo from './demos/ReadingFlowDemo/ReadingFlowDemo.vue'
 import readingFlowSnippetHtml from './demos/ReadingFlowDemo/ReadingFlowDemo.snippet.html?raw'
 import readingFlowSnippetCss from './demos/ReadingFlowDemo/ReadingFlowDemo.snippet.css?raw'
+import DetailsContentDemo from './demos/DetailsContentDemo/DetailsContentDemo.vue'
+import detailsContentSnippetHtml from './demos/DetailsContentDemo/DetailsContentDemo.snippet.html?raw'
+import detailsContentSnippetCss from './demos/DetailsContentDemo/DetailsContentDemo.snippet.css?raw'
 
 /** Per-showcase Baseline status, generated into baseline-data.json by
     scripts/gen-baseline.mjs from the web-features package (build-time — the
@@ -850,9 +853,32 @@ const entries: Omit<Showcase, 'tier'>[] = [
     snippetHtml: readingFlowSnippetHtml,
     snippetCss: readingFlowSnippetCss,
   },
+  {
+    id: 'details-content',
+    title: '::details-content',
+    supports: 'selector(::details-content)',
+    summary:
+      'A JS accordion re-implements what <details> gives away free: button ' +
+      'semantics, the announced expanded state, keyboard support. The missing ' +
+      'piece was always the animation — ::details-content styles the ' +
+      'browser’s own content region, and interpolate-size lets it glide ' +
+      'to its real auto height. Fades where only the pseudo is supported, ' +
+      'opens instantly where neither is — never broken, always native.',
+    links: [
+      {
+        label: 'MDN: ::details-content',
+        href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::details-content',
+      },
+    ],
+    payoff:
+      'The disclosure stays a real <details> — expanded state announced free of charge — while motion is layered on as pure enhancement, gone under reduced motion.',
+    tags: ['interaction', 'motion'],
+    component: DetailsContentDemo,
+    snippetHtml: detailsContentSnippetHtml,
+    snippetCss: detailsContentSnippetCss,
+  },
 
   // Further candidates: media state pseudo-classes (custom player),
-  // ::details-content + interpolate-size (animated native disclosure),
   // text-box trim.
 ]
 


### PR DESCRIPTION
A native \<details> FAQ with the smooth open it always lacked: ::details-content transitions opacity/block-size, allow-discrete holds content-visibility through the closing fade, interpolate-size animates to real auto height. Reduced motion gets instant toggling via an explicit gate — the global kill switch can't reach this pseudo. Degrades: Chrome glides, FF/Safari fade, elsewhere opens instantly.