### PR TITLE
fix: cite the legal map, drop the competing header rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ statement lives on the site. Found a barrier?
 [Open an issue](https://github.com/ThomasSweet/a11y-foundation/issues) — that
 feedback is welcome and acted on.
 
+## Thanks
+
+Feedback from these people changed the site. Named with their permission, and
+described by what they actually found, because "thanks for the feedback" is not
+a credit.
+
+- **[Imad Abdulkarim](https://github.com/fanckush)** — noticed that the
+  non-colour state cues vanished in iOS Safari, which turned out to be WebKit
+  declining to apply pseudo-element rules inside a style query. Also argued the
+  showcase read as "you don't need JavaScript" rather than accessibility, which
+  is why every entry now names who the feature helps, and asked for topic tags,
+  which became the catalog filter.
+
 ## Credits
 
 Two of the ideas here started as someone else's. The craft chapter's

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ feedback is welcome and acted on.
 
 ## Credits
 
+Two of the ideas here started as someone else's. The craft chapter's
+defensive-CSS section builds on **[Defensive CSS](https://defensivecss.dev/)**
+by [Ahmad Shadeed](https://ishadeed.com/) — guarding a layout against content
+you did not anticipate is his framing, and it is the whole premise of that
+section. The interest-invoker toolbar behaviour comes from a trick by
+[Una Kravets](https://una.im/). The implementations and the accessibility
+argument are mine; the insight was theirs.
+
 The decorative hero pictograms are
 [Material Symbols](https://github.com/google/material-design-icons) by Google,
 used under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/src/criteria/LegalMap/LegalMap.scss
+++ b/src/criteria/LegalMap/LegalMap.scss
@@ -69,6 +69,19 @@
     font-weight: 600;
   }
 
+  /* The name carries the link rather than a separate "source" affordance: the
+     underline is the cue, so it survives forced colors, and the row keeps the
+     accent for the WCAG reference alone. */
+  .legal-map-name a {
+    color: inherit;
+    text-decoration-color: var(--color-border);
+    text-underline-offset: 0.2em;
+  }
+
+  .legal-map-name a:hover {
+    text-decoration-color: currentcolor;
+  }
+
   .legal-map-ref {
     font-family: var(--font-mono);
     font-size: var(--text-sm);

--- a/src/criteria/LegalMap/LegalMap.vue
+++ b/src/criteria/LegalMap/LegalMap.vue
@@ -8,7 +8,7 @@
     <ul class="legal-map-laws">
       <li v-for="law in laws" :key="law.region" class="legal-map-law">
         <p class="legal-map-region">{{ law.region }}</p>
-        <p class="legal-map-name">{{ law.name }}</p>
+        <p class="legal-map-name"><a :href="law.href">{{ law.name }}</a></p>
         <p class="legal-map-ref">→ {{ law.references }}</p>
         <p class="legal-map-status">{{ law.status }}</p>
       </li>
@@ -18,9 +18,9 @@
       Accessibility law is global and converging: different jurisdictions wrap
       their own legal force around the <em>same</em> technical standard. Get
       WCAG right and you're most of the way to compliance everywhere.
-      <span class="legal-map-disclaimer">(A simplified snapshot — exact versions,
-      levels, and dates vary and keep evolving; check the current text for
-      your jurisdiction.)</span>
+      <span class="legal-map-disclaimer">(Orientation, not legal advice. Exact
+      versions, levels, and dates vary and keep evolving — every law above links
+      to its official text, last read {{ sourcesRead }}.)</span>
     </p>
   </div>
 </template>
@@ -31,7 +31,15 @@ interface Law {
   name: string
   references: string
   status: string
+  /** Official text, so a reader can verify the row instead of trusting it. */
+  href: string
 }
+
+/* Deliberately hand-set, never derived from the build date: a stamp that moved
+   on every deploy would claim a check nobody performed. Bump it only when the
+   rows below have actually been re-read against their sources. Law is
+   time-driven, not change-driven — it goes stale while the repo sits still. */
+const sourcesRead = '28 July 2026'
 
 const laws: Law[] = [
   {
@@ -39,24 +47,28 @@ const laws: Law[] = [
     name: 'European Accessibility Act → EN 301 549',
     references: 'WCAG 2.1 AA',
     status: 'In force since 28 Jun 2025',
+    href: 'https://eur-lex.europa.eu/eli/dir/2019/882/oj',
   },
   {
     region: 'United States · federal',
     name: 'Section 508',
     references: 'WCAG 2.0 AA',
     status: 'Required for federal ICT',
+    href: 'https://www.section508.gov/',
   },
   {
     region: 'United States · public sector',
     name: 'ADA Title II (DOJ 2024 rule)',
     references: 'WCAG 2.1 AA',
     status: 'Phasing in 2027–2028',
+    href: 'https://www.ada.gov/resources/2024-03-08-web-rule/',
   },
   {
     region: 'Canada',
     name: 'Accessible Canada Act · AODA (Ontario)',
     references: 'WCAG 2.0 AA',
     status: 'In force; scope expanding',
+    href: 'https://laws-lois.justice.gc.ca/eng/acts/A-0.6/',
   },
 ]
 </script>

--- a/src/site/ChapterLayout/ChapterLayout.scss
+++ b/src/site/ChapterLayout/ChapterLayout.scss
@@ -68,10 +68,13 @@
     }
   }
 
+  /* No rule under this label. The header's own bottom border already sets a
+     full-width line; a second fragment here and the headrow's dimension line
+     sat at different heights, reading as one broken line rather than two
+     deliberate ones. The dimension line stays because it measures something. */
   .chapter-rail-title {
     margin: 0 0 var(--space-3);
     padding-block-end: var(--space-2);
-    border-block-end: 1px solid var(--bp-line-strong);
     font-family: var(--bp-mono);
     font-size: 0.625rem;
     letter-spacing: 0.08em;


### PR DESCRIPTION
Every law in the legal map now links to its official text (EUR-Lex, ada.gov, section508.gov, Justice Laws), so a reader can verify a row instead of trusting it, and the section carries a hand-set "last read" date. That date is deliberately not derived from the build: a stamp that moved on every deploy would claim a check nobody performed. Law is time-driven, not change-driven, which is the same reason the Baseline job runs weekly.

Also removes the rule under the contents label. The header's full-width border plus two shorter rules at different heights read as one broken line rather than three deliberate ones. The headrow's dimension line stays, since it measures something.