### PR TITLE
feat: rounded polygon() showcase, You-are-here pointer tag, masterclass sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every feature the site teaches is doing real work *in* the site — each behind
   presets: visual themes, a color-vision-friendly trio, high-contrast pair.
 - **WCAG, live** — criteria demos on the standard's timeline, each with a
   **"break this rule"** toggle so you can feel what the criterion prevents.
-- **A CSS showcase catalog** — 31 accessible demos of modern platform
+- **A CSS showcase catalog** — 32 accessible demos of modern platform
   features, grouped into Baseline's own tiers from `web-features` data at
   build time, each with its a11y payoff spelled out and its code one click away.
 - **Preference & interaction mixins** — `reduced-motion()`, `forced-colors()`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,6 +168,98 @@ fixes/features as they come in.
   keep hunting for places where a showcased feature can do real chrome work with
   personality. Playfulness is a feature, not a garnish.
 
+### The masterclass sweep (July 2026) — specialist-lens gap analysis
+
+The exercise: what would an accessibility specialist and a senior
+accessibility engineer say is missing, if this site is meant to go past
+"what is a11y" into building solid foundations and auditing well? Verdict
+first: the four pillars hold. The real gaps cluster in three places — the
+**Understandable** principle is the thinnest pillar, **layout under user
+stress** (zoom, spacing, translation) is practised everywhere but taught
+nowhere, and the proof chapter argues the layered model without teaching
+the *practice* of auditing (screen-reader literacy, triage, reporting).
+Every candidate below keeps the house rules: interaction only when it IS
+the lesson, pure CSS/HTML mechanisms, JS-territory named as out of lane
+rather than half-covered.
+
+**POUR, honestly scored.** Perceivable: strong (contrast engine, theming,
+forced colors, reduced motion/transparency) — missing 1.4.12 and 1.4.13.
+Operable: strong (targets, focus appearance, bypass) — missing the sticky
+chrome/focus interaction. Understandable: thinnest — 3.3.7 and 3.2.6 stand
+almost alone; 1.3.5, 3.1.1/3.1.2 are absent or unnamed. Robust: the site
+*is* the demo (landmarks, headings, native elements) but never teaches the
+hiding-technique decisions every dev gets wrong; status messages (4.1.3)
+are JS and should be named as out of lane, not skipped silently.
+
+Craft-chapter candidates (pure CSS/HTML, each with the interactive hook):
+
+- **Text-spacing stress test (1.4.12)** — a toggle applies the WCAG
+  override values (line-height 1.5×, paragraph 2×, letter 0.12×, word
+  0.16×); the defensively-built card breathes, the fixed-height twin
+  clips. The 200%-zoom sibling of Break-it-with-content.
+- **The sticky bar that eats your focus (2.4.11)** — tab through a list
+  under a sticky header and watch focus land hidden behind it; then
+  `scroll-padding` on the scroller fixes it. The site does this
+  everywhere (`scroll-margin` on every `[id]`) and teaches it nowhere.
+- **The hiding matrix** — one specimen hidden four ways (`display:none`,
+  `.visually-hidden`, `aria-hidden`, `inert`) with a "what the screen
+  reader meets / what the keyboard meets" readout per technique. The
+  single most-asked junior question, rarely answered in one place.
+- **Truncation ethics** — `line-clamp` cuts content with no way to reach
+  it (1.4.10 / 1.4.4); pair the clamp with a native disclosure so the
+  full text stays reachable. Sits beside ::details-content.
+- **The scrollbar you shouldn't style** — `scrollbar-gutter: stable`,
+  the macOS-overlay vs Windows-classic split, and why scrollable regions
+  need to be keyboard-reachable (the site's `tabindex="0"` regions).
+  From the July sidebar thread; the lesson is restraint.
+- **Input purpose (1.3.5)** — a checkout form where `autocomplete`
+  tokens let the browser fill name/address/email; break-it removes the
+  tokens and autofill goes blind. Pure HTML; the `forms` tag exists and
+  is underfed. Could live on the timeline as a break-it criterion instead.
+- **content-visibility** — performance as accessibility, with the nuance
+  that (unlike `display:none`) skipped content stays findable and
+  announceable; find-in-page proves it live. Showcase candidate.
+- **`display: contents` warning** — not a demo; a CodeCompare "gotcha"
+  note. It stripped list/table semantics for years; still bites.
+
+Proof-chapter candidates (the premise says "audit effectively and
+efficiently" — the chapter argues the model, these teach the practice):
+
+- **A screen reader's first fifteen minutes** — VoiceOver/NVDA survival
+  card: the rotor, heading/landmark/form hops, why you don't narrate
+  every word. `<kbd>`-styled, printable. Best home may be a reference
+  sheet (A·03) off the title block, like the glossary and agent-skill
+  pages — reference, not argument.
+- **Reading the accessibility tree** — DevTools walkthrough: name, role,
+  value for the working dev; where the computed name actually comes from.
+- **Triage that survives a sprint** — severity as user-impact (task
+  blocked? how often? any workaround?), not WCAG level; plus the bug
+  template that names the barrier, the AT, the criterion, and the fix.
+  Copyable block; CodeBlock already does this job elsewhere.
+- **The audit room (capstone, big)** — an inert specimen page seeded
+  with a known number of barriers; visitors hunt them, hints and answers
+  behind `<details>`. Break-it scaled from one rule to a whole page; the
+  AuditStylesheet demo already proved the inert-specimen pattern. The
+  most "masterclass" idea here — also the most work; scope it standalone.
+- **Reader mode as an audit layer** — if semantic HTML is right, Reader
+  view works; a one-paragraph smoke test worth adding to the layers.
+- **WebAIM survey grounding** — the numbers (mobile SR share, top
+  frustrations) that turn "test on phones" from anecdote (article 01's
+  reviewers) into data. One sourced paragraph in the proof intro.
+
+Structure: nothing above needs a fifth pillar. Understandable items feed
+the timeline, stress/hiding/scrollbar feed craft, audit practice feeds
+proof, and cheat-sheet material extends the title-block reference sheets
+(A·03, A·04…) the way glossary and agent-skill already do. One addition
+worth making explicit *on the site*: a short "edge of the argument" note —
+ARIA widget patterns, live regions, and focus management are real, they
+are JavaScript's territory, and this site deliberately stops where the
+platform's free guarantees stop. Saying so is more credible than silence.
+
+Out of lane, stated once: captions/media (no media on the site), 4.1.3
+live regions, ARIA authoring patterns, focus management — JS mechanisms;
+the agent skill and the scope note can point at the ARIA APG instead.
+
 ### Watchlist (too early / conditional — revisit)
 
 - WCAG 2.2 timeline coverage — settled at 4 of the 9 new criteria (2.5.8,
@@ -183,6 +275,15 @@ fixes/features as they come in.
 - Media state pseudo-classes (`:playing` etc.) — checked July 2026: no
   Chromium support (Firefox 150 + Safari only, Baseline false per
   web-features); revisit when Chrome ships.
+- `text-fit` (a.k.a. the `text-grow`/`text-shrink` proposals) — assessed
+  July 2026: no engine ships it, so it can't be demoed honestly. The a11y
+  case is real but double-edged: *grow/fit* would retire images-of-text and
+  SVG `textLength` hacks for display headlines (real text that translates
+  and reads aloud), but *shrink per-line* can quietly fight the user — bump
+  your font size and the algorithm shrinks it back to fit, a 1.4.4 failure
+  mode with the same flavour as `maximum-scale=1`. If it ships: demo it as
+  display-type-only, never body or functional text, and lead with the
+  shrink caveat. Revisit when any engine lands it.
 - `sibling-index()` / `sibling-count()` — Canary only.
 - `border-shape` — spec in flux; candidate for the anchor-tooltip arrow.
 - Overscroll areas / built-in gestures — early spec discussion.
@@ -213,6 +314,8 @@ fixes/features as they come in.
 ## Done
 
 One line per item, newest first; details in git history / PRs.
+
+- **2026-07** Wave 9 showcase: rounded `polygon()` — real text vs an exported image of text (1.4.5), a break-it that clips the focus ring off the link, and the timeline's "You are here" label re-cut as a pointer tag (dogfood). Idea via Temani Afif's CSS Tip.
 
 - **2026-07** Agent Skill published (`skills/accessible-by-default`): hand-written decisions plus three reference files generated from the criteria and showcase registries (`npm run skill:gen`), so agents get the platform-first argument without the skill drifting from the demos. Suggested by a reviewer, after Chrome's Modern Web Guidance.
 - **2026-07** Launched: the multi-page redesign replaced the one-page site in production (old design kept at the `design-classic` tag), with a new brand mark, regenerated icons/OG image, and the style guide reskinned to match.

--- a/scripts/gen-baseline.mjs
+++ b/scripts/gen-baseline.mjs
@@ -15,7 +15,9 @@ import { fileURLToPath } from 'node:url'
 import { features } from 'web-features'
 
 /** Showcase id (registry) → web-features id. Combo demos without one clear
-    upstream feature are simply absent — no badge is rendered for them. */
+    upstream feature are simply absent — no badge is rendered for them.
+    polygon-round is absent on purpose: web-features has no id for the round
+    keyword yet, and 'shapes' (the pre-round basics) would claim the wrong tier. */
 const SHOWCASE_FEATURES = {
   'container-queries': 'container-queries',
   'cq-units': 'container-queries',

--- a/skills/accessible-by-default/references/css-snippets.md
+++ b/skills/accessible-by-default/references/css-snippets.md
@@ -552,6 +552,61 @@ check its tier in `modern-css.md` first.
 }
 ```
 
+## Rounded polygon()
+
+**Guard:** `@supports (clip-path: polygon(round 8px, 0 0, 100% 0, 50% 100%))`
+
+```html
+<!-- The ring lives on the <a>; the clip lives on the child. -->
+<a class="spec-link" href="/spec">
+  <span class="spec-tag">Read the spec</span>
+</a>
+```
+
+```css
+/* round softens every corner with one radius —
+   per-corner control is shape()'s job. */
+.spec-tag {
+  display: inline-block;
+  padding: 4px 26px 4px 12px;
+  background: #dbe7ff;
+  clip-path: polygon(
+    round 8px,
+    0 0,
+    calc(100% - 14px) 0,
+    100% 50%,
+    calc(100% - 14px) 100%,
+    0 100%
+  );
+}
+
+/* Clip the child, never the focusable element: clip-path cuts away
+   everything the element paints — a focus outline included. */
+.spec-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+/* Better: a ring that follows the shape. Drop-shadows on the UNclipped
+   parent trace the clipped child's silhouette — outline never can, and
+   on a clipped link the clip runs after filters and cuts the ring away. */
+@supports (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+  .spec-link:focus-visible {
+    outline: none;
+    filter: drop-shadow(2px 0 0 currentColor) drop-shadow(-2px 0 0 currentColor)
+      drop-shadow(0 2px 0 currentColor) drop-shadow(0 -2px 0 currentColor);
+  }
+}
+
+/* No support? A plain rounded chip, not a broken shape. */
+@supports not (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+  .spec-tag {
+    border-radius: 8px;
+    padding-inline-end: 12px;
+  }
+}
+```
+
 ## @starting-style
 
 **Guard:** `@supports (transition-behavior: allow-discrete)`

--- a/skills/accessible-by-default/references/modern-css.md
+++ b/skills/accessible-by-default/references/modern-css.md
@@ -312,6 +312,19 @@ Animations driven by scroll position instead of time — no scroll listeners, ru
 
 - [MDN: scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations)
 
+### Rounded polygon()
+
+An arrow tag used to be a rotated-box hack or an exported image — and the export took real text with it.
+
+**Accessibility payoff:** Labels that used to ship as images of text stay real text (1.4.5) — zoom reflows it, translation translates it, themes re-ink it, screen readers just read it.
+
+**Guard:** `@supports (clip-path: polygon(round 8px, 0 0, 100% 0, 50% 100%))`
+
+**Topics:** layout, typography
+
+- [MDN: polygon()](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/polygon)
+- [CSS Tip: rounded shapes (Temani Afif)](https://css-tip.com/rounded-shapes/)
+
 ### Advanced attr()
 
 attr() with types — read data attributes as lengths, colors, or numbers in any property, not just content.

--- a/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
+++ b/src/criteria/CriteriaTimeline/CriteriaTimeline.scss
@@ -193,6 +193,27 @@
     color: var(--color-primary);
   }
 
+  @supports (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+    .timeline-now-label {
+      padding: var(--space-1) calc(var(--space-3) + 12px) var(--space-1) var(--space-3);
+      background-color: var(--bp-accent-soft);
+      clip-path: polygon(
+        round 6px,
+        0 0,
+        calc(100% - 12px) 0,
+        100% 50%,
+        calc(100% - 12px) 100%,
+        0 100%
+      );
+
+      @include forced-colors {
+        padding: 0;
+        background-color: transparent;
+        clip-path: none;
+      }
+    }
+  }
+
   .timeline-now-year {
     font-family: var(--font-mono);
     font-weight: 400;

--- a/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.snippet.css
+++ b/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.snippet.css
@@ -1,0 +1,41 @@
+/* round softens every corner with one radius —
+   per-corner control is shape()'s job. */
+.spec-tag {
+  display: inline-block;
+  padding: 4px 26px 4px 12px;
+  background: #dbe7ff;
+  clip-path: polygon(
+    round 8px,
+    0 0,
+    calc(100% - 14px) 0,
+    100% 50%,
+    calc(100% - 14px) 100%,
+    0 100%
+  );
+}
+
+/* Clip the child, never the focusable element: clip-path cuts away
+   everything the element paints — a focus outline included. */
+.spec-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+/* Better: a ring that follows the shape. Drop-shadows on the UNclipped
+   parent trace the clipped child's silhouette — outline never can, and
+   on a clipped link the clip runs after filters and cuts the ring away. */
+@supports (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+  .spec-link:focus-visible {
+    outline: none;
+    filter: drop-shadow(2px 0 0 currentColor) drop-shadow(-2px 0 0 currentColor)
+      drop-shadow(0 2px 0 currentColor) drop-shadow(0 -2px 0 currentColor);
+  }
+}
+
+/* No support? A plain rounded chip, not a broken shape. */
+@supports not (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+  .spec-tag {
+    border-radius: 8px;
+    padding-inline-end: 12px;
+  }
+}

--- a/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.snippet.html
+++ b/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.snippet.html
@@ -1,0 +1,4 @@
+<!-- The ring lives on the <a>; the clip lives on the child. -->
+<a class="spec-link" href="/spec">
+  <span class="spec-tag">Read the spec</span>
+</a>

--- a/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.vue
+++ b/src/showcases/demos/RoundedClipDemo/RoundedClipDemo.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="rounded-clip-demo">
+    <div class="rounded-clip-pair">
+      <figure class="rounded-clip-half">
+        <img
+          class="rounded-clip-image"
+          :src="exportedTag"
+          alt="Detail A — a label exported as an image"
+          width="132"
+          height="36"
+        />
+        <figcaption class="rounded-clip-caption">
+          The old way: an exported image. Switch the theme — it stays lit.
+          Zoom — the text can't reflow. A translator can't touch it.
+        </figcaption>
+      </figure>
+
+      <figure class="rounded-clip-half">
+        <p class="rounded-clip-tag">Detail A</p>
+        <figcaption class="rounded-clip-caption">
+          Real text under a rounded clip. It re-inks with every theme, wraps
+          under zoom, translates, and reads aloud.
+        </figcaption>
+      </figure>
+    </div>
+
+    <div class="rounded-clip-focus">
+      <label class="rounded-clip-break">
+        <input class="rounded-clip-break-input" type="checkbox" />
+        Break it: clip the link element itself
+      </label>
+
+      <a
+        class="rounded-clip-link"
+        href="https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/polygon"
+      >
+        <span class="rounded-clip-link-tag">Read the spec</span>
+      </a>
+
+      <p class="rounded-clip-note">
+        Tab to the link: the ring follows the arrow because it is drawn on
+        the unclipped <code>&lt;a&gt;</code> — drop-shadows tracing the
+        clipped child's silhouette, something <code>outline</code> can never
+        do. Break it and the clip, now on the link itself, cuts the ring
+        away with everything else the element paints. The clip is the hit
+        area too — a pointed tag is pointed for the pointer.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/* A stand-in for a designer's asset export: baked colors, baked text. */
+const exportedTag =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="132" height="36">' +
+      '<path d="M8 0 H118 L132 18 L118 36 H8 A8 8 0 0 1 0 28 V8 A8 8 0 0 1 8 0 Z" fill="#d8e4f7"/>' +
+      '<text x="14" y="23" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13" letter-spacing="0.5" fill="#274b8f">DETAIL A</text>' +
+      '</svg>',
+  )
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .rounded-clip-demo {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .rounded-clip-pair {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+  }
+
+  .rounded-clip-half {
+    display: grid;
+    gap: var(--space-2);
+    justify-items: start;
+    margin: 0;
+    min-inline-size: 0;
+  }
+
+  .rounded-clip-image {
+    display: block;
+  }
+
+  .rounded-clip-caption,
+  .rounded-clip-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .rounded-clip-tag,
+  .rounded-clip-link-tag {
+    display: inline-block;
+    margin: 0;
+    padding: var(--space-1) var(--space-3);
+    border-radius: var(--radius-md);
+    background-color: color-mix(in oklab, var(--color-primary) 14%, var(--color-surface));
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-text);
+
+    @include forced-colors {
+      border: 1px solid;
+    }
+  }
+
+  @supports (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+    .rounded-clip-tag,
+    .rounded-clip-link-tag {
+      border-radius: 0;
+      padding-inline-end: calc(var(--space-3) + 14px);
+      clip-path: polygon(
+        round 8px,
+        0 0,
+        calc(100% - 14px) 0,
+        100% 50%,
+        calc(100% - 14px) 100%,
+        0 100%
+      );
+
+      /* Forced colors override the fill the shape is cut from — fall back
+         to the bordered chip instead of an invisible outline. */
+      @include forced-colors {
+        border-radius: var(--radius-md);
+        padding-inline-end: var(--space-3);
+        clip-path: none;
+      }
+    }
+
+    .rounded-clip-demo:has(.rounded-clip-break-input:checked) {
+      .rounded-clip-link {
+        clip-path: polygon(
+          round 8px,
+          0 0,
+          calc(100% - 14px) 0,
+          100% 50%,
+          calc(100% - 14px) 100%,
+          0 100%
+        );
+
+        @include forced-colors {
+          clip-path: none;
+        }
+      }
+
+      .rounded-clip-link-tag {
+        clip-path: none;
+      }
+    }
+
+    /* The ring that follows the shape: four drop-shadows on the UNclipped
+       parent trace the child's clipped silhouette — outline draws the border
+       box and never can. The preferences-layer ring beats any components
+       outline: none by design, so it is re-inked transparent on this one
+       element instead, with the visible colour captured on the parent first.
+       Forced colors are excluded: the system ring stays in charge there.
+       On the broken link the clip runs after filters, so even this ring is
+       cut away — which is the lesson. */
+    @media (forced-colors: none) {
+      .rounded-clip-focus {
+        --rounded-clip-ring: var(--focus-ring-color);
+      }
+
+      .rounded-clip-link:focus-visible {
+        --focus-ring-color: transparent;
+
+        filter: drop-shadow(var(--focus-ring-width) 0 0 var(--rounded-clip-ring))
+          drop-shadow(calc(-1 * var(--focus-ring-width)) 0 0 var(--rounded-clip-ring))
+          drop-shadow(0 var(--focus-ring-width) 0 var(--rounded-clip-ring))
+          drop-shadow(0 calc(-1 * var(--focus-ring-width)) 0 var(--rounded-clip-ring));
+      }
+    }
+  }
+
+  .rounded-clip-focus {
+    display: grid;
+    gap: var(--space-3);
+    justify-items: start;
+  }
+
+  .rounded-clip-break {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+
+    /* Nested so the emitted rule always follows the display above —
+       a sibling block at equal specificity loses to source order. */
+    @supports not (clip-path: polygon(round 1px, 0 0, 1% 0, 0 1%)) {
+      display: none;
+    }
+  }
+
+  .rounded-clip-link {
+    display: inline-block;
+    text-decoration: none;
+  }
+}
+</style>

--- a/src/showcases/registry.ts
+++ b/src/showcases/registry.ts
@@ -32,6 +32,7 @@ import ThemePickerDemo from './demos/ThemePickerDemo/ThemePickerDemo.vue'
 import SlidingIndicatorDemo from './demos/SlidingIndicatorDemo/SlidingIndicatorDemo.vue'
 import StyleQueryCuesDemo from './demos/StyleQueryCuesDemo/StyleQueryCuesDemo.vue'
 import ShapeDemo from './demos/ShapeDemo/ShapeDemo.vue'
+import RoundedClipDemo from './demos/RoundedClipDemo/RoundedClipDemo.vue'
 import StartingStyleDemo from './demos/StartingStyleDemo/StartingStyleDemo.vue'
 import AttrDemo from './demos/AttrDemo/AttrDemo.vue'
 import ScrollSnapDemo from './demos/ScrollSnapDemo/ScrollSnapDemo.vue'
@@ -77,6 +78,8 @@ import themePickerSnippetCss from './demos/ThemePickerDemo/ThemePickerDemo.snipp
 import scrollProgressSnippetCss from './demos/ScrollProgressDemo/ScrollProgressDemo.snippet.css?raw'
 import styleQuerySnippetCss from './demos/StyleQueryCuesDemo/StyleQueryCuesDemo.snippet.css?raw'
 import shapeSnippetCss from './demos/ShapeDemo/ShapeDemo.snippet.css?raw'
+import roundedClipSnippetHtml from './demos/RoundedClipDemo/RoundedClipDemo.snippet.html?raw'
+import roundedClipSnippetCss from './demos/RoundedClipDemo/RoundedClipDemo.snippet.css?raw'
 import startingStyleSnippetCss from './demos/StartingStyleDemo/StartingStyleDemo.snippet.css?raw'
 import attrSnippetHtml from './demos/AttrDemo/AttrDemo.snippet.html?raw'
 import attrSnippetCss from './demos/AttrDemo/AttrDemo.snippet.css?raw'
@@ -563,6 +566,38 @@ const entries: Omit<Showcase, 'tier'>[] = [
     tags: ['layout'],
     component: ShapeDemo,
     snippetCss: shapeSnippetCss,
+  },
+  {
+    id: 'polygon-round',
+    title: 'Rounded polygon()',
+    supports: 'clip-path: polygon(round 8px, 0 0, 100% 0, 50% 100%)',
+    summary:
+      'An arrow tag used to be a rotated-box hack or an exported image — ' +
+      'and the export took real text with it. The round keyword makes the ' +
+      'shape one declaration on ordinary markup, so the text comes back: it ' +
+      'reflows under zoom, translates, re-inks with themes, reads aloud. ' +
+      'The craft is where the clip goes: clip a child, keep the focusable ' +
+      'element unclipped, and the focus ring can even follow the shape — ' +
+      'drop-shadows on the parent trace the clipped silhouette, which ' +
+      'outline never can. Break it to see why: clip the link itself and ' +
+      'every ring is cut away with the rest of what it paints. One radius ' +
+      'rounds every corner; per-corner control is shape()’s job.',
+    links: [
+      {
+        label: 'MDN: polygon()',
+        href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/polygon',
+      },
+      {
+        label: 'CSS Tip: rounded shapes (Temani Afif)',
+        href: 'https://css-tip.com/rounded-shapes/',
+      },
+    ],
+    payoff:
+      'Labels that used to ship as images of text stay real text (1.4.5) — zoom reflows it, translation translates it, themes re-ink it, screen readers just read it.',
+    tags: ['layout', 'typography'],
+    component: RoundedClipDemo,
+    snippetHtml: roundedClipSnippetHtml,
+    snippetCss: roundedClipSnippetCss,
   },
   {
     id: 'starting-style',


### PR DESCRIPTION
New showcase (32nd): polygon()'s round keyword as the retirement of rotated-box hacks and exported images of text — real text under a rounded clip vs a frozen export, and a break-it that moves the clip onto the link itself. The focus ring follows the shape: drop-shadows on the unclipped parent trace the clipped child's silhouette (outline can only draw the border box), and the preferences-layer ring is re-inked transparent on this one element rather than fought — forced colors keep the system ring. On the broken link the clip runs after filters, so even that ring is cut away, which is the lesson. Unmapped in gen-baseline on purpose: web-features has no id for round yet, and 'shapes' would claim the wrong tier.

Dogfood: the timeline's "You are here" label is now a pointer tag behind the same @supports guard.

ROADMAP: specialist-lens gap analysis (POUR scoring, craft/proof candidates, audit-room capstone, reference-sheet routing) and a text-fit watchlist entry with the shrink-vs-user-zoom caveat.