### PR TITLE
feat: quick-wins content sweep across craft and proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ cp -r skills/accessible-by-default ~/.claude/skills/
 
 The reference files are generated from the same registries the site renders
 (`npm run skill:gen`), so the skill can't drift from the live demos. The idea
-came from reviewer feedback, alongside Chrome's
+came from [Jakub Andrzejewski](https://x.com/jacobandrewsky), alongside Chrome's
 [Modern Web Guidance](https://developer.chrome.com/docs/modern-web-guidance).
 
 ## Try it with your OS preferences
@@ -180,6 +180,10 @@ a credit.
   The theme panel was flying out detached from its button on wide screens; it is
   anchored now. The second turned out to be correct behaviour, and explaining
   why Space scrolls and Enter activates was worth the trip on its own.
+- **[Jakub Andrzejewski](https://x.com/jacobandrewsky)** — asked whether the
+  whole argument could ship in a form AI agents can use. That question became
+  the Agent Skill and its page — arguably the most portable thing the project
+  produces.
 - **My wife** — caught that the end-of-chapter links were too small and easy to
   miss, which is why they are full cards now, and has been the steady source of
   pointers and ideas behind a lot of the rest.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,10 +24,15 @@ git history and the PRs, not here.
 - iOS zoom-in/zoom-out sometimes lands in a different section — needs the
   tester's video to reproduce; suspects: scroll anchoring vs sticky
   ghosts / scroll-driven timelines.
-- Per-topic reference links (MDN/spec) on craft demos — the one leftover
-  from the restructure thread.
 - A public `/llms.txt` as the agent-skill follow-up — needs page-level
   markdown the site doesn't emit yet.
+- Distribution (Anthony's push): get the project into curated lists —
+  the accessibility side (brunopulis/awesome-a11y, The A11y Project's
+  resources page, an A11y Weekly link suggestion) and the agent side,
+  where "a11y for AI agents" is a near-empty niche (VoltAgent/
+  awesome-agent-skills and the awesome-claude-skills lists). Also worth
+  a shot: CSS/frontend newsletters for the showcase itself. Draft the
+  PR/blurb texts once, submit by hand.
 
 - The project itself as a showcase (open, directional) — my worry after the
   restructure: some playfulness got lost, and the site chrome should *itself*
@@ -55,8 +60,8 @@ rather than half-covered.
 
 **POUR, honestly scored.** Perceivable: strong (contrast engine, theming,
 forced colors, reduced motion/transparency) — missing 1.4.12 and 1.4.13.
-Operable: strong (targets, focus appearance, bypass) — missing the sticky
-chrome/focus interaction. Understandable: thinnest — 3.3.7 and 3.2.6 stand
+Operable: strong (targets, focus appearance, bypass, and 2.4.11's sticky-bar
+break-it already exists). Understandable: thinnest — 3.3.7 and 3.2.6 stand
 almost alone; 1.3.5, 3.1.1/3.1.2 are absent or unnamed. Robust: the site
 *is* the demo (landmarks, headings, native elements) but never teaches the
 hiding-technique decisions every dev gets wrong; status messages (4.1.3)
@@ -68,21 +73,10 @@ Craft-chapter candidates (pure CSS/HTML, each with the interactive hook):
   override values (line-height 1.5×, paragraph 2×, letter 0.12×, word
   0.16×); the defensively-built card breathes, the fixed-height twin
   clips. The 200%-zoom sibling of Break-it-with-content.
-- **The sticky bar that eats your focus (2.4.11)** — tab through a list
-  under a sticky header and watch focus land hidden behind it; then
-  `scroll-padding` on the scroller fixes it. The site does this
-  everywhere (`scroll-margin` on every `[id]`) and teaches it nowhere.
 - **The hiding matrix** — one specimen hidden four ways (`display:none`,
   `.visually-hidden`, `aria-hidden`, `inert`) with a "what the screen
   reader meets / what the keyboard meets" readout per technique. The
   single most-asked junior question, rarely answered in one place.
-- **Truncation ethics** — `line-clamp` cuts content with no way to reach
-  it (1.4.10 / 1.4.4); pair the clamp with a native disclosure so the
-  full text stays reachable. Sits beside ::details-content.
-- **The scrollbar you shouldn't style** — `scrollbar-gutter: stable`,
-  the macOS-overlay vs Windows-classic split, and why scrollable regions
-  need to be keyboard-reachable (the site's `tabindex="0"` regions).
-  From the July sidebar thread; the lesson is restraint.
 - **Input purpose (1.3.5)** — a checkout form where `autocomplete`
   tokens let the browser fill name/address/email; break-it removes the
   tokens and autofill goes blind. Pure HTML; the `forms` tag exists and
@@ -90,8 +84,6 @@ Craft-chapter candidates (pure CSS/HTML, each with the interactive hook):
 - **content-visibility** — performance as accessibility, with the nuance
   that (unlike `display:none`) skipped content stays findable and
   announceable; find-in-page proves it live. Showcase candidate.
-- **`display: contents` warning** — not a demo; a CodeCompare "gotcha"
-  note. It stripped list/table semantics for years; still bites.
 
 Proof-chapter candidates (the premise says "audit effectively and
 efficiently" — the chapter argues the model, these teach the practice):
@@ -112,33 +104,22 @@ efficiently" — the chapter argues the model, these teach the practice):
   behind `<details>`. Break-it scaled from one rule to a whole page; the
   AuditStylesheet demo already proved the inert-specimen pattern. The
   most "masterclass" idea here — also the most work; scope it standalone.
-- **Reader mode as an audit layer** — if semantic HTML is right, Reader
-  view works; a one-paragraph smoke test worth adding to the layers.
-- **WebAIM survey grounding** — the numbers (mobile SR share, top
-  frustrations) that turn "test on phones" from anecdote (article 01's
-  reviewers) into data. One sourced paragraph in the proof intro.
-
 Structure: nothing above needs a fifth pillar. Understandable items feed
-the timeline, stress/hiding/scrollbar feed craft, audit practice feeds
+the timeline, the hiding/stress work feeds craft, audit practice feeds
 proof, and cheat-sheet material extends the title-block reference sheets
-(A·03, A·04…) the way glossary and agent-skill already do. One addition
-worth making explicit *on the site*: a short "edge of the argument" note —
-ARIA widget patterns, live regions, and focus management are real, they
-are JavaScript's territory, and this site deliberately stops where the
-platform's free guarantees stop. Saying so is more credible than silence.
+(A·03, A·04…) the way glossary and agent-skill already do.
 
-Out of lane, stated once: captions/media (no media on the site), 4.1.3
-live regions, ARIA authoring patterns, focus management — JS mechanisms;
-the agent skill and the scope note can point at the ARIA APG instead.
+Out of lane — now stated on the site ("Where this argument stops", end of
+proof): captions/media (no media on the site), 4.1.3 live regions, ARIA
+authoring patterns, focus management — JS mechanisms; the section points
+at the ARIA APG.
 
 ### Watchlist (too early / conditional — revisit)
 
-- WCAG 2.2 timeline coverage — settled at 4 of the 9 new criteria (2.5.8,
-  2.4.11, 2.4.13, 3.3.7); the rest assessed July 2026 and skipped on purpose:
-  2.4.12 near-duplicates the 2.4.11 demo at AAA, 2.5.7 and 3.3.8 need JS
-  mechanisms to break honestly. **3.2.6 Consistent Help is unblocked now
-  that the multi-page design is going live — a good first post-launch demo**
-  (help lives in the same footer slot on every page; break-it moves it).
+- WCAG 2.2 timeline coverage — settled at 5 of the 9 new criteria (2.5.8,
+  2.4.11, 2.4.13, 3.2.6, 3.3.7); the rest assessed July 2026 and skipped on
+  purpose: 2.4.12 near-duplicates the 2.4.11 demo at AAA, 2.5.7 and 3.3.8
+  need JS mechanisms to break honestly.
 - `text-box` (trim) — Chrome + Safari; typographic alignment with only a
   modest a11y angle; take it only if a showcase gap needs filling.
 - Subgrid card alignment — only if criteria/showcase cards ever sit side by
@@ -198,6 +179,8 @@ the agent skill and the scope note can point at the ARIA APG instead.
 
 One line per item, newest first; details in git history / PRs.
 
+- **2026-07** Quick-wins content sweep: truncation craft demo (a clamped `<details>` preview via `::details-content` — the clamp IS the disclosure), "the scrollbar you leave alone" demo (`scrollbar-gutter: stable` + keyboard-reachable regions), the `display: contents` subgrid gotcha pair, reference links on all ten craft demos, WebAIM Survey 10 numbers + reader-mode smoke test in proof, and a "Where this argument stops" scope section pointing at the ARIA APG.
+
 - **2026-07** Stage wash pinned to the viewport (fixed pseudo-element) — the showcase filter used to re-stretch the page-length gradient behind the sheet.
 - **2026-07** Wave 9 showcase: rounded `polygon()` — real text vs an exported image of text (1.4.5), a break-it that clips the focus ring off the link, a drop-shadow focus ring that follows the shape, and the timeline's "You are here" label re-cut as a pointer tag (dogfood). Idea via Temani Afif's CSS Tip.
 - **2026-07** Sidebar rail scroll-spy rebuilt on an opacity-only overlay after four defects in the colour-animation mechanism; theme flips re-ink via plain declarations.
@@ -222,7 +205,7 @@ One line per item, newest first; details in git history / PRs.
   subtraction + the ruled title block from Klara's review, and the
   end-of-chapter pager grown into plate cards after my wife caught how
   hidden it was.
-- **2026-07** Agent Skill published (`skills/accessible-by-default`): hand-written decisions plus three reference files generated from the criteria and showcase registries (`npm run skill:gen`), so agents get the platform-first argument without the skill drifting from the demos. Suggested by a reviewer, after Chrome's Modern Web Guidance.
+- **2026-07** Agent Skill published (`skills/accessible-by-default`): hand-written decisions plus three reference files generated from the criteria and showcase registries (`npm run skill:gen`), so agents get the platform-first argument without the skill drifting from the demos. Suggested by Jakub Andrzejewski, after Chrome's Modern Web Guidance.
 - **2026-07** Launched: the multi-page redesign replaced the one-page site in production (old design kept at the `design-classic` tag), with a new brand mark, regenerated icons/OG image, and the style guide reskinned to match.
 - **2026-07** Timeline: 3.2.6 Consistent Help break-it demo — three page mock-ups whose help link either holds its slot or wanders; the first criterion the multi-page structure made demoable.
 - **2026-07** ESLint added (flat config, vue + typescript, `--max-warnings 0`, wired into CI) — the JS/TS gate that stylelint and vue-tsc never covered.

--- a/src/craft/CraftLinks/CraftLinks.vue
+++ b/src/craft/CraftLinks/CraftLinks.vue
@@ -1,0 +1,27 @@
+<template>
+  <ul class="craft-links">
+    <li v-for="link in links" :key="link.href">
+      <a :href="link.href">{{ link.label }}</a>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  links: { label: string; href: string }[]
+}>()
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .craft-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: var(--text-sm);
+  }
+}
+</style>

--- a/src/craft/demos/ScrollbarDemo.vue
+++ b/src/craft/demos/ScrollbarDemo.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="scrollbar-demo">
+    <label class="scrollbar-demo-toggle">
+      <input class="scrollbar-demo-input" type="checkbox" />
+      Give the panes more text than fits
+    </label>
+
+    <div class="scrollbar-demo-panes">
+      <section class="scrollbar-demo-pane" tabindex="0" aria-label="Pane without a reserved gutter">
+        <p class="scrollbar-demo-tag">default</p>
+        <p class="scrollbar-demo-text">{{ opening }}</p>
+        <p class="scrollbar-demo-text scrollbar-demo-extra">{{ overflow }}</p>
+      </section>
+
+      <section
+        class="scrollbar-demo-pane scrollbar-demo-pane-stable"
+        tabindex="0"
+        aria-label="Pane with scrollbar-gutter: stable"
+      >
+        <p class="scrollbar-demo-tag">scrollbar-gutter: stable</p>
+        <p class="scrollbar-demo-text">{{ opening }}</p>
+        <p class="scrollbar-demo-text scrollbar-demo-extra">{{ overflow }}</p>
+      </section>
+    </div>
+
+    <p class="scrollbar-demo-note">
+      What you see depends on your OS: classic scrollbars (Windows, or macOS
+      with "always show") take layout space, so the left pane's text reflows
+      the moment the scrollbar arrives — the right pane reserved the space
+      up front. Overlay scrollbars occupy no space, and no CSS can change
+      which kind your visitor has. Both panes are keyboard-scrollable via
+      <code>tabindex="0"</code> and a label.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const opening =
+  'A settings page holds a scrollable list of integrations. On one OS the ' +
+  'scrollbar floats above the content; on another it takes twelve pixels of ' +
+  'layout. The same stylesheet serves both.'
+
+const overflow =
+  'The moment the list grows past its box, a classic scrollbar claims its ' +
+  'lane and every line of text re-wraps a few pixels narrower — unless the ' +
+  'lane was reserved before it was needed.'
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .scrollbar-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .scrollbar-demo-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .scrollbar-demo-panes {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+  }
+
+  .scrollbar-demo-pane {
+    min-inline-size: 0;
+    block-size: 11rem;
+    overflow-y: auto;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    &:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: 2px;
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .scrollbar-demo-pane-stable {
+    scrollbar-gutter: stable;
+  }
+
+  .scrollbar-demo-tag {
+    margin-block-end: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .scrollbar-demo-text {
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: 1.55;
+  }
+
+  .scrollbar-demo-text + .scrollbar-demo-text {
+    margin-block-start: var(--space-2);
+  }
+
+  .scrollbar-demo-extra {
+    display: none;
+  }
+
+  .scrollbar-demo:has(.scrollbar-demo-input:checked) .scrollbar-demo-extra {
+    display: block;
+  }
+
+  .scrollbar-demo-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/craft/demos/TruncationDemo.vue
+++ b/src/craft/demos/TruncationDemo.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="truncation-demo">
+    <article class="truncation-card" aria-labelledby="truncation-dead-end">
+      <p id="truncation-dead-end" class="truncation-card-label">Clamped, with no way in</p>
+      <p class="truncation-clamped">{{ description }}</p>
+    </article>
+
+    <article class="truncation-card" aria-labelledby="truncation-disclosure">
+      <p id="truncation-disclosure" class="truncation-card-label">
+        Clamped, and the clamp is a disclosure
+      </p>
+      <details class="truncation-details">
+        <summary class="truncation-summary">Full description</summary>
+        <p class="truncation-full">{{ description }}</p>
+      </details>
+    </article>
+  </div>
+</template>
+
+<script setup lang="ts">
+const description =
+  'Version 4.2 rebuilds the export pipeline around streamed rendering, so a ' +
+  'report that used to assemble in memory now starts downloading on the first ' +
+  'row. Scheduled exports pick up the same engine, along with per-column ' +
+  'formatting, a duplicate-header fix for merged sheets, and clearer error ' +
+  'messages when a data source goes away mid-run. Anyone on the legacy ' +
+  'formatter keeps it until the end of the quarter, and both engines write ' +
+  'identical files for every format except the retired binary one.'
+</script>
+
+<style scoped lang="scss">
+@layer components {
+  .truncation-demo {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  }
+
+  .truncation-card {
+    min-inline-size: 0;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .truncation-card-label {
+    margin-block-end: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .truncation-clamped,
+  .truncation-full {
+    margin: 0;
+    font-size: var(--text-sm);
+    line-height: 1.55;
+  }
+
+  /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
+  .truncation-clamped {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+  }
+
+  @supports selector(::details-content) {
+    .truncation-details:not([open])::details-content {
+      content-visibility: visible;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      overflow: hidden;
+    }
+  }
+  /* stylelint-enable value-no-vendor-prefix, property-no-vendor-prefix */
+
+  .truncation-details {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .truncation-summary {
+    inline-size: fit-content;
+    min-block-size: 24px;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: 2px;
+    }
+  }
+
+  @supports selector(::details-content) {
+    .truncation-details:not([open]) .truncation-summary {
+      order: 1;
+    }
+  }
+}
+</style>

--- a/src/craft/snippets.ts
+++ b/src/craft/snippets.ts
@@ -112,6 +112,67 @@ input:user-invalid {
 }`,
   },
 
+  // Mirrors TruncationDemo — the clamp that is also the disclosure.
+  truncation: {
+    language: 'CSS',
+    mistake: `/* Three lines survive; the rest of the content is gone
+   for sighted users, with nothing to open. (A screen
+   reader still gets all of it — the two audiences now
+   read different documents.) */
+.teaser {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}`,
+    craft: `/* Clamp the closed state of a real <details>: the preview
+   is the collapsed disclosure itself — expanded state
+   announced natively, nothing duplicated. */
+details:not([open])::details-content {
+  content-visibility: visible;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}`,
+  },
+
+  // Mirrors ScrollbarDemo — reserve the gutter, leave the rest alone.
+  scrollbar: {
+    language: 'CSS',
+    mistake: `/* Restyled scrollbars: invisible in Firefox (different
+   syntax), often low-contrast, thinner than any touch
+   target — and overlay-scrollbar users see none of it. */
+.panel::-webkit-scrollbar { width: 4px; }
+.panel::-webkit-scrollbar-thumb { background: #ddd; }`,
+    craft: `/* Reserve the scrollbar's lane so content doesn't reflow
+   when it appears, and keep the native bar. (The region
+   itself gets tabindex="0" and a label for keyboard use.) */
+.panel {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}`,
+  },
+
+  // The display:contents trap — layout wins, list semantics lose.
+  displayContents: {
+    language: 'CSS',
+    mistake: `/* Flattening a list into the parent grid. For years this
+   stripped list semantics from assistive tech (Safari
+   still relapses) — the layout wins, the <ul> vanishes. */
+ul.cards {
+  display: contents;
+}`,
+    craft: `/* Subgrid aligns the items to the page grid while the
+   list keeps its box and its semantics. If you must use
+   display:contents, re-test with a screen reader. */
+ul.cards {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
+}`,
+  },
+
   // Mirrors LoadingStateDemo — aria-busy + one hidden line.
   loading: {
     language: 'HTML',

--- a/src/pages/CraftPage.vue
+++ b/src/pages/CraftPage.vue
@@ -39,6 +39,7 @@
         />
       </div>
       <CodeCompare v-bind="craftSnippets.validation" />
+      <CraftLinks :links="craftLinks.validation" />
     </section>
 
     <section class="demo" aria-labelledby="craft-light-dark" style="view-timeline-name: --chapter-sec-2">
@@ -51,6 +52,7 @@
         eventually edits half of. Same result, half the surface area for bugs.
       </p>
       <LightDarkDemo />
+      <CraftLinks :links="craftLinks.lightDark" />
     </section>
 
     <section class="demo" aria-labelledby="craft-dialog" style="view-timeline-name: --chapter-sec-3">
@@ -75,6 +77,7 @@
         </p>
       </AppDialog>
       <CodeCompare v-bind="craftSnippets.dialog" />
+      <CraftLinks :links="craftLinks.dialog" />
     </section>
 
     <section class="demo" aria-labelledby="craft-motion" style="view-timeline-name: --chapter-sec-4">
@@ -89,6 +92,7 @@
       </p>
       <MotionDemo />
       <CodeCompare v-bind="craftSnippets.motion" />
+      <CraftLinks :links="craftLinks.motion" />
     </section>
 
     <section class="demo" aria-labelledby="craft-targets" style="view-timeline-name: --chapter-sec-5">
@@ -102,6 +106,7 @@
       </p>
       <TargetsDemo />
       <CodeCompare v-bind="craftSnippets.targets" />
+      <CraftLinks :links="craftLinks.targets" />
     </section>
 
     <section class="demo" aria-labelledby="craft-defensive" style="view-timeline-name: --chapter-sec-6">
@@ -123,6 +128,7 @@
       </p>
       <DefensiveCssDemo />
       <CodeCompare v-bind="craftSnippets.defensive" />
+      <CraftLinks :links="craftLinks.defensive" />
     </section>
 
     <section class="demo" aria-labelledby="craft-content-stress" style="view-timeline-name: --chapter-sec-7">
@@ -141,6 +147,19 @@
       </p>
       <ContentStressDemo />
       <CodeCompare v-bind="craftSnippets.contentStress" />
+      <p>
+        One more content-shaped trap: flattening a list with
+        <code>display: contents</code> so its items can sit on the parent
+        grid. For years that stripped the list's semantics from assistive
+        tech — and Safari has relapsed more than once. Subgrid gets the same
+        alignment without the sacrifice.
+      </p>
+      <CodeCompare
+        v-bind="craftSnippets.displayContents"
+        mistake-label="The tempting flatten"
+        craft-label="Subgrid instead"
+      />
+      <CraftLinks :links="craftLinks.contentStress" />
     </section>
 
     <section class="demo" aria-labelledby="craft-loading" style="view-timeline-name: --chapter-sec-8">
@@ -162,6 +181,51 @@
       </p>
       <LoadingStateDemo />
       <CodeCompare v-bind="craftSnippets.loading" />
+      <CraftLinks :links="craftLinks.loading" />
+    </section>
+
+    <section class="demo" aria-labelledby="craft-truncation" style="view-timeline-name: --chapter-sec-9">
+      <h3 id="craft-truncation">Truncation that keeps a way in</h3>
+      <p>
+        <code>line-clamp</code> cuts a paragraph to a tidy three lines — and
+        for a sighted visitor, everything past the clamp simply stops
+        existing, because the property is visual-only and ships no control
+        to open it. A screen reader still gets the full text, so the two
+        audiences quietly read different documents. The craft move: make
+        the clamp itself the collapsed state of a native
+        <code>&lt;details&gt;</code> — <code>::details-content</code>
+        normally hides closed content, but overriding its
+        <code>content-visibility</code> leaves a clamped preview showing.
+        One element, expanded state announced for free, nothing duplicated.
+        Browsers without the pseudo-element fall back to an ordinary closed
+        disclosure. And when the content is essential, the honest fix is
+        simpler: don't clamp it.
+      </p>
+      <TruncationDemo />
+      <CodeCompare v-bind="craftSnippets.truncation" />
+      <CraftLinks :links="craftLinks.truncation" />
+    </section>
+
+    <section class="demo" aria-labelledby="craft-scrollbar" style="view-timeline-name: --chapter-sec-10">
+      <h3 id="craft-scrollbar">The scrollbar you leave alone</h3>
+      <p>
+        Scrollbars are OS territory the page only borrows. On macOS they
+        float above content by default and take no space; on Windows and
+        for anyone who sets "always show", they claim a lane — and when one
+        appears mid-interaction, every line of text re-wraps around it.
+        <code>scrollbar-gutter: stable</code> reserves the lane before it's
+        needed, which is the one scrollbar property worth adopting. The
+        rest is restraint: restyled scrollbars use syntax Firefox ignores,
+        tend toward thin low-contrast thumbs that hurt exactly the people
+        scrollbars serve most, and are invisible to overlay users anyway —
+        while the native bar already follows <code>color-scheme</code> into
+        dark mode. What a scrollable region does need is
+        <code>tabindex="0"</code> and a label, so keyboard users can reach
+        and scroll it at all.
+      </p>
+      <ScrollbarDemo />
+      <CodeCompare v-bind="craftSnippets.scrollbar" />
+      <CraftLinks :links="craftLinks.scrollbar" />
     </section>
   </ChapterLayout>
 </template>
@@ -180,7 +244,10 @@ import TargetsDemo from '../craft/demos/TargetsDemo.vue'
 import DefensiveCssDemo from '../craft/demos/DefensiveCssDemo.vue'
 import ContentStressDemo from '../craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from '../craft/demos/LoadingStateDemo.vue'
+import TruncationDemo from '../craft/demos/TruncationDemo.vue'
+import ScrollbarDemo from '../craft/demos/ScrollbarDemo.vue'
 import CodeCompare from '../craft/CodeCompare/CodeCompare.vue'
+import CraftLinks from '../craft/CraftLinks/CraftLinks.vue'
 import { craftSnippets } from '../craft/snippets'
 
 const name = ref('')
@@ -196,5 +263,94 @@ const sections = [
   { id: 'craft-defensive', label: 'Layouts that expect the worst' },
   { id: 'craft-content-stress', label: 'Break it with content' },
   { id: 'craft-loading', label: 'Loading states the tree can see' },
+  { id: 'craft-truncation', label: 'Truncation with a way in' },
+  { id: 'craft-scrollbar', label: 'The scrollbar left alone' },
 ]
+
+const craftLinks = {
+  validation: [
+    {
+      label: 'MDN: :user-invalid',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid',
+    },
+    {
+      label: 'WCAG 3.3.1 Error Identification',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html',
+    },
+  ],
+  lightDark: [
+    {
+      label: 'MDN: light-dark()',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark',
+    },
+  ],
+  dialog: [
+    {
+      label: 'MDN: <dialog>',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog',
+    },
+  ],
+  motion: [
+    {
+      label: 'MDN: prefers-reduced-motion',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion',
+    },
+    {
+      label: 'WCAG 2.3.3 Animation from Interactions',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html',
+    },
+  ],
+  targets: [
+    {
+      label: 'WCAG 2.5.8 Target Size',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html',
+    },
+    {
+      label: 'MDN: forced-colors',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors',
+    },
+  ],
+  defensive: [
+    {
+      label: 'Defensive CSS (Ahmad Shadeed)',
+      href: 'https://defensivecss.dev/',
+    },
+  ],
+  contentStress: [
+    {
+      label: 'MDN: hyphens',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens',
+    },
+    {
+      label: 'MDN: logical properties',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values',
+    },
+  ],
+  loading: [
+    {
+      label: 'MDN: aria-busy',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy',
+    },
+  ],
+  truncation: [
+    {
+      label: 'MDN: -webkit-line-clamp',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp',
+    },
+    {
+      label: 'MDN: ::details-content',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::details-content',
+    },
+  ],
+  scrollbar: [
+    {
+      label: 'MDN: scrollbar-gutter',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter',
+    },
+    {
+      label: 'WCAG 2.1.1 Keyboard',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html',
+    },
+  ],
+}
 </script>

--- a/src/pages/ProofPage.vue
+++ b/src/pages/ProofPage.vue
@@ -17,7 +17,26 @@
         can judge. None replaces the next. Every layer below points at the
         real artifact in this repo — the suite you can open and run.
       </p>
+      <p>
+        The layers also answer a fair question: tested for <em>whom</em>? In
+        <a href="https://webaim.org/projects/screenreadersurvey10/">WebAIM's
+        tenth screen-reader survey</a> (1,539 respondents, early 2024),
+        91.3% reported using a screen reader on a mobile device — while most
+        testing happens at a desktop. And the frustrations they ranked
+        highest — CAPTCHA, interactive elements behaving unexpectedly,
+        unclear links and buttons — are judgment calls no scanner flags.
+        Only about a third felt the web had become more accessible. The
+        layered model exists because the failures that matter most live
+        where automation isn't looking.
+      </p>
       <TestingLayers />
+      <p>
+        One more layer costs nothing and isn't in the diagram: reader mode.
+        It rebuilds the page from semantics alone — headings, lists, article
+        structure — so a page that survives the trip probably has its bones
+        right, and a page reader mode can't parse is one a screen reader is
+        likely fighting too. Thirty seconds, no tooling.
+      </p>
     </section>
 
     <section class="demo" aria-labelledby="testing-coverage" style="view-timeline-name: --chapter-sec-2">
@@ -67,6 +86,24 @@
         assistive-tech experience stays quick.
       </p>
     </section>
+
+    <section class="demo" aria-labelledby="testing-edge" style="view-timeline-name: --chapter-sec-5">
+      <h3 id="testing-edge">Where this argument stops</h3>
+      <p>
+        Everything on this site stays on one side of a line: what HTML and
+        CSS guarantee before any JavaScript arrives. The other side is real,
+        and application work lands on it daily — ARIA widget patterns, live
+        regions that announce what just changed, focus management after a
+        route change or a deletion. Those are JavaScript's territory,
+        harder to get right than anything shown here, and claiming CSS
+        covers them would be exactly the kind of overclaim this site
+        argues against. When you cross the line, the
+        <a href="https://www.w3.org/WAI/ARIA/apg/">ARIA Authoring Practices
+        Guide</a> is the map — and the habit from this chapter still
+        applies: test what you build, in layers, with the people and tools
+        the layers stand in for.
+      </p>
+    </section>
   </ChapterLayout>
 </template>
 
@@ -82,5 +119,6 @@ const sections = [
   { id: 'testing-coverage', label: "What automation can and can't see" },
   { id: 'testing-audit-css', label: 'CSS that audits' },
   { id: 'testing-performance', label: 'Performance is accessibility' },
+  { id: 'testing-edge', label: 'Where this argument stops' },
 ]
 </script>


### PR DESCRIPTION
Craft grows to ten sections: a truncation demo where the clamp is the collapsed state of a native details (content-visibility override on ::details-content — preview while closed, announced expansion, nothing duplicated), a scrollbar demo built on scrollbar-gutter: stable and the case for leaving native bars alone, and a display:contents gotcha pair under Break it with content. Every craft section gains a reference-links row (MDN + WCAG understanding pages).

Proof gains WebAIM Survey 10 grounding (91.3% mobile screen-reader use; the top frustrations are judgment calls no scanner flags), reader mode as the zero-tooling smoke test, and a closing "Where this argument stops" section that names ARIA widgets, live regions, and focus management as JavaScript's territory and points at the ARIA APG.