### PR TITLE
feat: craft wave — the hiding matrix and the 1.4.12 text-spacing test

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,14 +69,6 @@ are JS and should be named as out of lane, not skipped silently.
 
 Craft-chapter candidates (pure CSS/HTML, each with the interactive hook):
 
-- **Text-spacing stress test (1.4.12)** — a toggle applies the WCAG
-  override values (line-height 1.5×, paragraph 2×, letter 0.12×, word
-  0.16×); the defensively-built card breathes, the fixed-height twin
-  clips. The 200%-zoom sibling of Break-it-with-content.
-- **The hiding matrix** — one specimen hidden four ways (`display:none`,
-  `.visually-hidden`, `aria-hidden`, `inert`) with a "what the screen
-  reader meets / what the keyboard meets" readout per technique. The
-  single most-asked junior question, rarely answered in one place.
 - **Input purpose (1.3.5)** — a checkout form where `autocomplete`
   tokens let the browser fill name/address/email; break-it removes the
   tokens and autofill goes blind. Pure HTML; the `forms` tag exists and
@@ -178,6 +170,8 @@ at the ARIA APG.
 ## Done
 
 One line per item, newest first; details in git history / PRs.
+
+- **2026-07** Craft wave: the hiding matrix (four techniques × visible/tree/tab-order, live inert specimen, the aria-hidden + `tabindex="-1"` pairing shown) and the 1.4.12 text-spacing stress test (toggle applies the reader's override values; the fixed-height card clips, the flexible one breathes). Craft is at twelve sections; rail scope extended to match.
 
 - **2026-07** Quick-wins content sweep: truncation craft demo (a clamped `<details>` preview via `::details-content` — the clamp IS the disclosure), "the scrollbar you leave alone" demo (`scrollbar-gutter: stable` + keyboard-reachable regions), the `display: contents` subgrid gotcha pair, reference links on all ten craft demos, WebAIM Survey 10 numbers + reader-mode smoke test in proof, and a "Where this argument stops" scope section pointing at the ARIA APG.
 

--- a/src/craft/demos/HidingMatrixDemo.vue
+++ b/src/craft/demos/HidingMatrixDemo.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="hiding-demo">
+    <article class="hiding-card" aria-labelledby="hiding-display-none">
+      <p id="hiding-display-none" class="hiding-card-label">display: none</p>
+      <div class="hiding-specimen">
+        <div class="hiding-gone">
+          <p>This paragraph and its button render nowhere.</p>
+          <button type="button" class="hiding-control">Example control</button>
+        </div>
+      </div>
+      <ul class="hiding-readout">
+        <li><span aria-hidden="true">✕</span> not visible</li>
+        <li><span aria-hidden="true">✕</span> not in the accessibility tree</li>
+        <li><span aria-hidden="true">✕</span> not in the tab order</li>
+      </ul>
+      <p class="hiding-use">For content that is gone for everyone: closed panels, inactive views.</p>
+    </article>
+
+    <article class="hiding-card" aria-labelledby="hiding-visually-hidden">
+      <p id="hiding-visually-hidden" class="hiding-card-label">.visually-hidden</p>
+      <div class="hiding-specimen">
+        <p class="visually-hidden">
+          A screen reader reads this sentence even though the box looks empty.
+        </p>
+      </div>
+      <ul class="hiding-readout">
+        <li><span aria-hidden="true">✕</span> not visible</li>
+        <li><span aria-hidden="true">✓</span> in the accessibility tree</li>
+        <li>
+          <span aria-hidden="true">✓</span> controls stay in the tab order — an
+          invisible focus stop, unless you use a focusable variant that appears
+          on focus (this site's skip link)
+        </li>
+      </ul>
+      <p class="hiding-use">For screen-reader-only context: labels, hints, state announcements.</p>
+    </article>
+
+    <article class="hiding-card" aria-labelledby="hiding-aria-hidden">
+      <p id="hiding-aria-hidden" class="hiding-card-label">aria-hidden="true"</p>
+      <div class="hiding-specimen" aria-hidden="true">
+        <p>Fully visible, and a screen reader will never mention it.</p>
+        <button type="button" class="hiding-control" tabindex="-1">Example control</button>
+      </div>
+      <ul class="hiding-readout">
+        <li><span aria-hidden="true">✓</span> visible</li>
+        <li><span aria-hidden="true">✕</span> not in the accessibility tree</li>
+        <li>
+          <span aria-hidden="true">✓</span> controls stay in the tab order
+          unless you also remove them (the button here carries
+          <code>tabindex="-1"</code>)
+        </li>
+      </ul>
+      <p class="hiding-use">For decorative or duplicated visuals — never for anything interactive.</p>
+    </article>
+
+    <article class="hiding-card" aria-labelledby="hiding-inert">
+      <p id="hiding-inert" class="hiding-card-label">inert</p>
+      <div class="hiding-specimen hiding-specimen-inert" inert>
+        <p>Visible but switched off — try clicking or tabbing to the button.</p>
+        <button type="button" class="hiding-control">Example control</button>
+      </div>
+      <ul class="hiding-readout">
+        <li><span aria-hidden="true">✓</span> visible</li>
+        <li><span aria-hidden="true">✕</span> not in the accessibility tree</li>
+        <li><span aria-hidden="true">✕</span> not in the tab order, not clickable</li>
+      </ul>
+      <p class="hiding-use">For visible-but-inactive regions: the page behind a modal, a disabled step.</p>
+    </article>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@layer components {
+  .hiding-demo {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  }
+
+  .hiding-card {
+    display: grid;
+    gap: var(--space-3);
+    align-content: start;
+    min-inline-size: 0;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .hiding-card-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .hiding-specimen {
+    display: grid;
+    gap: var(--space-2);
+    justify-items: start;
+    min-block-size: 5.5rem;
+    padding: var(--space-3);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .hiding-specimen-inert {
+    opacity: 0.55;
+  }
+
+  .hiding-gone {
+    display: none;
+  }
+
+  .hiding-control {
+    min-block-size: 24px;
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-subtle);
+    font: inherit;
+    font-size: var(--text-sm);
+    cursor: pointer;
+
+    &:active {
+      translate: 0 1px;
+    }
+
+    &:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: 2px;
+    }
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .hiding-readout {
+    display: grid;
+    gap: var(--space-1);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-size: var(--text-sm);
+
+    li {
+      padding-inline-start: var(--space-4);
+      text-indent: calc(var(--space-4) * -1);
+    }
+  }
+
+  .hiding-use {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/craft/demos/TextSpacingDemo.vue
+++ b/src/craft/demos/TextSpacingDemo.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="text-spacing-demo">
+    <label class="text-spacing-toggle">
+      <input class="text-spacing-input" type="checkbox" />
+      Apply the 1.4.12 spacing overrides
+    </label>
+
+    <div class="text-spacing-pair">
+      <article class="text-spacing-card">
+        <p class="text-spacing-tag">lets the text grow</p>
+        <div class="text-spacing-content">
+          <p class="text-spacing-heading">Shipping update</p>
+          <p>
+            Orders placed before noon leave the same day, and every parcel
+            gets a tracking link the moment the label prints.
+          </p>
+          <p>
+            During launch weeks the cut-off moves an hour earlier, and the
+            status page carries the current one.
+          </p>
+          <p>
+            Returns ride the same tracking link, and a refund starts the
+            moment the carrier scans the parcel back in.
+          </p>
+        </div>
+      </article>
+
+      <article class="text-spacing-card text-spacing-card-frozen">
+        <p class="text-spacing-tag">a fixed block-size, clipped</p>
+        <div class="text-spacing-content">
+          <p class="text-spacing-heading">Shipping update</p>
+          <p>
+            Orders placed before noon leave the same day, and every parcel
+            gets a tracking link the moment the label prints.
+          </p>
+          <p>
+            During launch weeks the cut-off moves an hour earlier, and the
+            status page carries the current one.
+          </p>
+          <p>
+            Returns ride the same tracking link, and a refund starts the
+            moment the carrier scans the parcel back in.
+          </p>
+        </div>
+      </article>
+    </div>
+
+    <p class="text-spacing-note">
+      The toggle applies what a reader's browser extension or user stylesheet
+      applies for real: line height 1.5, letter spacing 0.12em, word spacing
+      0.16em, paragraph spacing 2em. The flexible card grows; the
+      pixel-perfect one starts eating sentences.
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@layer components {
+  .text-spacing-demo {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .text-spacing-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    justify-self: start;
+    font-size: var(--text-sm);
+    font-weight: 600;
+  }
+
+  .text-spacing-pair {
+    display: grid;
+    gap: var(--space-4);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+    align-items: start;
+  }
+
+  .text-spacing-card {
+    min-inline-size: 0;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-surface);
+
+    @include high-contrast {
+      border-color: currentcolor;
+    }
+  }
+
+  .text-spacing-card-frozen {
+    block-size: 15rem;
+    overflow: clip;
+  }
+
+  .text-spacing-tag {
+    margin-block-end: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+
+  .text-spacing-content {
+    font-size: var(--text-sm);
+
+    p {
+      margin: 0;
+    }
+
+    p + p {
+      margin-block-start: var(--space-2);
+    }
+  }
+
+  .text-spacing-heading {
+    font-weight: 600;
+  }
+
+  .text-spacing-demo:has(.text-spacing-input:checked) .text-spacing-content {
+    line-height: 1.5;
+    letter-spacing: 0.12em;
+    word-spacing: 0.16em;
+
+    p + p {
+      margin-block-start: 2em;
+    }
+  }
+
+  .text-spacing-note {
+    font-size: var(--text-sm);
+    color: var(--color-text-subtle);
+  }
+}
+</style>

--- a/src/craft/links.ts
+++ b/src/craft/links.ts
@@ -1,0 +1,108 @@
+/** Per-section reference links rendered by CraftLinks under each craft demo. */
+export interface CraftLink {
+  label: string
+  href: string
+}
+
+export const craftLinks = {
+  validation: [
+    {
+      label: 'MDN: :user-invalid',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid',
+    },
+    {
+      label: 'WCAG 3.3.1 Error Identification',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html',
+    },
+  ],
+  lightDark: [
+    {
+      label: 'MDN: light-dark()',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark',
+    },
+  ],
+  dialog: [
+    {
+      label: 'MDN: <dialog>',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog',
+    },
+  ],
+  motion: [
+    {
+      label: 'MDN: prefers-reduced-motion',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion',
+    },
+    {
+      label: 'WCAG 2.3.3 Animation from Interactions',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html',
+    },
+  ],
+  targets: [
+    {
+      label: 'WCAG 2.5.8 Target Size',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html',
+    },
+    {
+      label: 'MDN: forced-colors',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors',
+    },
+  ],
+  defensive: [
+    {
+      label: 'Defensive CSS (Ahmad Shadeed)',
+      href: 'https://defensivecss.dev/',
+    },
+  ],
+  contentStress: [
+    {
+      label: 'MDN: hyphens',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens',
+    },
+    {
+      label: 'MDN: logical properties',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values',
+    },
+  ],
+  loading: [
+    {
+      label: 'MDN: aria-busy',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy',
+    },
+  ],
+  truncation: [
+    {
+      label: 'MDN: -webkit-line-clamp',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp',
+    },
+    {
+      label: 'MDN: ::details-content',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::details-content',
+    },
+  ],
+  scrollbar: [
+    {
+      label: 'MDN: scrollbar-gutter',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter',
+    },
+    {
+      label: 'WCAG 2.1.1 Keyboard',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html',
+    },
+  ],
+  hiding: [
+    {
+      label: 'MDN: inert',
+      href: 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert',
+    },
+    {
+      label: 'WebAIM: invisible content',
+      href: 'https://webaim.org/techniques/css/invisiblecontent/',
+    },
+  ],
+  textSpacing: [
+    {
+      label: 'WCAG 1.4.12 Text Spacing',
+      href: 'https://www.w3.org/WAI/WCAG22/Understanding/text-spacing.html',
+    },
+  ],
+} satisfies Record<string, CraftLink[]>

--- a/src/craft/snippets.ts
+++ b/src/craft/snippets.ts
@@ -173,6 +173,41 @@ ul.cards {
 }`,
   },
 
+  // Mirrors HidingMatrixDemo — hide for the right audience.
+  hiding: {
+    language: 'CSS',
+    mistake: `/* "Hidden" by eye only: invisible, but still announced
+   by screen readers and still a tab stop — keyboard
+   users land on nothing. */
+.menu {
+  opacity: 0;
+}`,
+    craft: `/* Pick the technique by audience, not by looks:
+   gone for everyone      → display: none
+   screen readers only    → .visually-hidden
+   visible but inactive   → the inert attribute */
+.menu[data-closed] {
+  display: none;
+}`,
+  },
+
+  // Mirrors TextSpacingDemo — boxes that survive the 1.4.12 overrides.
+  textSpacing: {
+    language: 'CSS',
+    mistake: `/* A pixel-perfect text box. The moment a reader raises
+   line height or letter spacing (WCAG 1.4.12 says they
+   may), the last sentences are clipped away. */
+.card {
+  height: 176px;
+  overflow: hidden;
+}`,
+    craft: `/* Set a floor, never a ceiling — the box grows with the
+   reader's spacing instead of eating their text. */
+.card {
+  min-block-size: 176px;
+}`,
+  },
+
   // Mirrors LoadingStateDemo — aria-busy + one hidden line.
   loading: {
     language: 'HTML',

--- a/src/pages/CraftPage.vue
+++ b/src/pages/CraftPage.vue
@@ -7,8 +7,7 @@
       each one is the accessible default.
     </p>
 
-    <section class="demo" aria-labelledby="craft-validation" style="view-timeline-name: --chapter-sec-1">
-      <h3 id="craft-validation">Validation that waits its turn</h3>
+    <ChapterSection id="craft-validation" :n="1" title="Validation that waits its turn">
       <p>
         Validation leans on the platform: native constraints
         (<code>required</code>, <code>type="email"</code>) drive the styling
@@ -40,10 +39,9 @@
       </div>
       <CodeCompare v-bind="craftSnippets.validation" />
       <CraftLinks :links="craftLinks.validation" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-light-dark" style="view-timeline-name: --chapter-sec-2">
-      <h3 id="craft-light-dark">Dark mode from one source of truth</h3>
+    <ChapterSection id="craft-light-dark" :n="2" title="Dark mode from one source of truth">
       <p>
         Theming is a place craft pays off quietly. Declaring each colour once
         with <code>light-dark()</code> keeps the light and dark values
@@ -53,10 +51,9 @@
       </p>
       <LightDarkDemo />
       <CraftLinks :links="craftLinks.lightDark" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-dialog" style="view-timeline-name: --chapter-sec-3">
-      <h3 id="craft-dialog">Native dialog, zero trapping code</h3>
+    <ChapterSection id="craft-dialog" :n="3" title="Native dialog, zero trapping code">
       <p>
         A native <code>&lt;dialog&gt;</code> with <code>showModal()</code>
         gives you focus trapping, Esc-to-close, and an inert background from
@@ -78,10 +75,9 @@
       </AppDialog>
       <CodeCompare v-bind="craftSnippets.dialog" />
       <CraftLinks :links="craftLinks.dialog" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-motion" style="view-timeline-name: --chapter-sec-4">
-      <h3 id="craft-motion">Motion that bows out on request</h3>
+    <ChapterSection id="craft-motion" :n="4" title="Motion that bows out on request">
       <p>
         Three independent animations, one preference. When the OS asks for
         reduced motion, all of them still — handled globally in
@@ -93,10 +89,9 @@
       <MotionDemo />
       <CodeCompare v-bind="craftSnippets.motion" />
       <CraftLinks :links="craftLinks.motion" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-targets" style="view-timeline-name: --chapter-sec-5">
-      <h3 id="craft-targets">Targets that survive touch and forced colors</h3>
+    <ChapterSection id="craft-targets" :n="5" title="Targets that survive touch and forced colors">
       <p>
         Hover styles only apply on devices that can actually hover; touch
         devices get larger targets via <code>touch-primary()</code>. In
@@ -107,10 +102,9 @@
       <TargetsDemo />
       <CodeCompare v-bind="craftSnippets.targets" />
       <CraftLinks :links="craftLinks.targets" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-defensive" style="view-timeline-name: --chapter-sec-6">
-      <h3 id="craft-defensive">Layouts that expect the worst</h3>
+    <ChapterSection id="craft-defensive" :n="6" title="Layouts that expect the worst">
       <p>
         Defensive CSS is the habit of assuming real content will be longer,
         wider, and weirder than the mockup. Designs are composed with tidy
@@ -129,10 +123,9 @@
       <DefensiveCssDemo />
       <CodeCompare v-bind="craftSnippets.defensive" />
       <CraftLinks :links="craftLinks.defensive" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-content-stress" style="view-timeline-name: --chapter-sec-7">
-      <h3 id="craft-content-stress">Break it with content</h3>
+    <ChapterSection id="craft-content-stress" :n="7" title="Break it with content">
       <p>
         Layouts don't break in design reviews; they break the day the CMS
         delivers a title nobody planned for. The habit that catches it
@@ -160,10 +153,9 @@
         craft-label="Subgrid instead"
       />
       <CraftLinks :links="craftLinks.contentStress" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-loading" style="view-timeline-name: --chapter-sec-8">
-      <h3 id="craft-loading">Loading states the accessibility tree can see</h3>
+    <ChapterSection id="craft-loading" :n="8" title="Loading states the accessibility tree can see">
       <p>
         Skeleton screens are a perceived-performance trick for the eyes:
         grey shapes promise that content is on its way. But placeholders
@@ -182,10 +174,9 @@
       <LoadingStateDemo />
       <CodeCompare v-bind="craftSnippets.loading" />
       <CraftLinks :links="craftLinks.loading" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-truncation" style="view-timeline-name: --chapter-sec-9">
-      <h3 id="craft-truncation">Truncation that keeps a way in</h3>
+    <ChapterSection id="craft-truncation" :n="9" title="Truncation that keeps a way in">
       <p>
         <code>line-clamp</code> cuts a paragraph to a tidy three lines — and
         for a sighted visitor, everything past the clamp simply stops
@@ -204,10 +195,9 @@
       <TruncationDemo />
       <CodeCompare v-bind="craftSnippets.truncation" />
       <CraftLinks :links="craftLinks.truncation" />
-    </section>
+    </ChapterSection>
 
-    <section class="demo" aria-labelledby="craft-scrollbar" style="view-timeline-name: --chapter-sec-10">
-      <h3 id="craft-scrollbar">The scrollbar you leave alone</h3>
+    <ChapterSection id="craft-scrollbar" :n="10" title="The scrollbar you leave alone">
       <p>
         Scrollbars are OS territory the page only borrows. On macOS they
         float above content by default and take no space; on Windows and
@@ -226,7 +216,46 @@
       <ScrollbarDemo />
       <CodeCompare v-bind="craftSnippets.scrollbar" />
       <CraftLinks :links="craftLinks.scrollbar" />
-    </section>
+    </ChapterSection>
+
+    <ChapterSection id="craft-hiding" :n="11" title="Four ways to hide, and whom they hide from">
+      <p>
+        "How do I hide this?" is the wrong question — the right one is
+        <em>from whom</em>. <code>display: none</code> removes content for
+        everyone: eyes, screen readers, the Tab key. The
+        <code>.visually-hidden</code> pattern removes it for eyes only,
+        which is how labels and hints reach a screen reader without
+        cluttering the layout — but any control inside stays tabbable, so
+        focus can land on nothing visible. <code>aria-hidden</code> is the
+        mirror image: fully visible, silent to assistive tech, and it does
+        <em>not</em> touch the tab order, which is why it must never wrap
+        anything interactive. And <code>inert</code> switches a visible
+        region off for everyone at once — the modern answer for the page
+        behind a modal. Native <code>&lt;dialog&gt;</code> applies it to
+        the whole background for free.
+      </p>
+      <HidingMatrixDemo />
+      <CodeCompare v-bind="craftSnippets.hiding" />
+      <CraftLinks :links="craftLinks.hiding" />
+    </ChapterSection>
+
+    <ChapterSection id="craft-text-spacing" :n="12" title="Text spacing is the reader's setting">
+      <p>
+        WCAG 1.4.12 grants readers the right to raise line height to 1.5,
+        letter spacing to 0.12em, word spacing to 0.16em, and paragraph
+        spacing to 2em — people with dyslexia or low vision do this
+        through extensions and user stylesheets, and the page has to
+        survive it with no loss of content or function. What breaks is
+        never the text; it's the pixel-perfect box around it. The toggle
+        below does exactly what a reader's override does: the flexible
+        card breathes, the fixed-height one clips sentences mid-thought.
+        The craft is one habit — heights on text containers are floors
+        (<code>min-block-size</code>), never ceilings.
+      </p>
+      <TextSpacingDemo />
+      <CodeCompare v-bind="craftSnippets.textSpacing" />
+      <CraftLinks :links="craftLinks.textSpacing" />
+    </ChapterSection>
   </ChapterLayout>
 </template>
 
@@ -234,6 +263,7 @@
 import { ref } from 'vue'
 
 import ChapterLayout from '../site/ChapterLayout/ChapterLayout.vue'
+import ChapterSection from '../site/ChapterSection/ChapterSection.vue'
 import GlossaryRef from '../glossary/GlossaryRef.vue'
 import TextField from '../components/TextField/TextField.vue'
 import AppButton from '../components/AppButton/AppButton.vue'
@@ -246,9 +276,12 @@ import ContentStressDemo from '../craft/demos/ContentStressDemo.vue'
 import LoadingStateDemo from '../craft/demos/LoadingStateDemo.vue'
 import TruncationDemo from '../craft/demos/TruncationDemo.vue'
 import ScrollbarDemo from '../craft/demos/ScrollbarDemo.vue'
+import HidingMatrixDemo from '../craft/demos/HidingMatrixDemo.vue'
+import TextSpacingDemo from '../craft/demos/TextSpacingDemo.vue'
 import CodeCompare from '../craft/CodeCompare/CodeCompare.vue'
 import CraftLinks from '../craft/CraftLinks/CraftLinks.vue'
 import { craftSnippets } from '../craft/snippets'
+import { craftLinks } from '../craft/links'
 
 const name = ref('')
 const email = ref('')
@@ -265,92 +298,7 @@ const sections = [
   { id: 'craft-loading', label: 'Loading states the tree can see' },
   { id: 'craft-truncation', label: 'Truncation with a way in' },
   { id: 'craft-scrollbar', label: 'The scrollbar left alone' },
+  { id: 'craft-hiding', label: 'Four ways to hide' },
+  { id: 'craft-text-spacing', label: "The reader's text spacing" },
 ]
-
-const craftLinks = {
-  validation: [
-    {
-      label: 'MDN: :user-invalid',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid',
-    },
-    {
-      label: 'WCAG 3.3.1 Error Identification',
-      href: 'https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html',
-    },
-  ],
-  lightDark: [
-    {
-      label: 'MDN: light-dark()',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark',
-    },
-  ],
-  dialog: [
-    {
-      label: 'MDN: <dialog>',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog',
-    },
-  ],
-  motion: [
-    {
-      label: 'MDN: prefers-reduced-motion',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion',
-    },
-    {
-      label: 'WCAG 2.3.3 Animation from Interactions',
-      href: 'https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html',
-    },
-  ],
-  targets: [
-    {
-      label: 'WCAG 2.5.8 Target Size',
-      href: 'https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html',
-    },
-    {
-      label: 'MDN: forced-colors',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors',
-    },
-  ],
-  defensive: [
-    {
-      label: 'Defensive CSS (Ahmad Shadeed)',
-      href: 'https://defensivecss.dev/',
-    },
-  ],
-  contentStress: [
-    {
-      label: 'MDN: hyphens',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens',
-    },
-    {
-      label: 'MDN: logical properties',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values',
-    },
-  ],
-  loading: [
-    {
-      label: 'MDN: aria-busy',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy',
-    },
-  ],
-  truncation: [
-    {
-      label: 'MDN: -webkit-line-clamp',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp',
-    },
-    {
-      label: 'MDN: ::details-content',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/::details-content',
-    },
-  ],
-  scrollbar: [
-    {
-      label: 'MDN: scrollbar-gutter',
-      href: 'https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter',
-    },
-    {
-      label: 'WCAG 2.1.1 Keyboard',
-      href: 'https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html',
-    },
-  ],
-}
 </script>

--- a/src/site/ChapterLayout/ChapterLayout.scss
+++ b/src/site/ChapterLayout/ChapterLayout.scss
@@ -11,7 +11,8 @@
     .chapter {
       timeline-scope: --chapter-sec-1, --chapter-sec-2, --chapter-sec-3,
         --chapter-sec-4, --chapter-sec-5, --chapter-sec-6, --chapter-sec-7,
-        --chapter-sec-8, --chapter-sec-9, --chapter-sec-10;
+        --chapter-sec-8, --chapter-sec-9, --chapter-sec-10, --chapter-sec-11,
+        --chapter-sec-12;
     }
 
     /* Animate only opacity here — colour-keyed versions cached keyframe var()s

--- a/src/site/ChapterSection/ChapterSection.vue
+++ b/src/site/ChapterSection/ChapterSection.vue
@@ -1,0 +1,16 @@
+<template>
+  <section class="demo" :aria-labelledby="id" :style="{ viewTimelineName: `--chapter-sec-${n}` }">
+    <h3 :id="id">{{ title }}</h3>
+    <slot />
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  /** Anchor id — must match the entry in ChapterLayout's sections list. */
+  id: string
+  /** 1-based position, feeding the rail's --chapter-sec-N view timeline. */
+  n: number
+  title: string
+}>()
+</script>


### PR DESCRIPTION
Two sections close the Robust and Perceivable gaps from the masterclass sweep. The hiding matrix answers "hidden from whom": four live specimens (display:none, .visually-hidden, aria-hidden, inert) each with a visible/tree/tab-order readout — inert proven live, aria-hidden shown with the tabindex="-1" pairing it requires. The text-spacing test applies the reader's 1.4.12 override values from one toggle: the flexible card grows, the fixed-height card clips mid-sentence, and the craft is heights-as-floors (min-block-size). Rail timeline-scope extended for twelve craft sections.

refactor: extract ChapterSection and the craft links module Twelve sections shared six lines of section/heading/timeline plumbing each — now a 16-line wrapper owns it, and the reference-links data moves to src/craft/links.ts beside snippets.ts. Rendered output is unchanged (anchor ids, aria-labelledby, per-section view timelines verified).